### PR TITLE
enable `--tailscale` option

### DIFF
--- a/scripts/dev.ts
+++ b/scripts/dev.ts
@@ -17,6 +17,7 @@ const getFlagValue = (flag: string) => {
 
 const pnpmCmd = process.platform === "win32" ? "pnpm.cmd" : "pnpm";
 const isPublic = hasFlag("--public");
+const isTailscale = hasFlag("--tailscale");
 const serverPort = getFlagValue("--server-port");
 
 const stripAnsi = (input: string) => {
@@ -68,6 +69,9 @@ const startServer = (webPort: number) => {
   const args = ["--filter", "@tmux-agent-monitor/server", "dev", "--"];
   if (isPublic) {
     args.push("--public");
+  }
+  if (isTailscale) {
+    args.push("--tailscale");
   }
   if (serverPort) {
     args.push("--port", serverPort);


### PR DESCRIPTION
I added it because the `--tailscale` options weren't usable with pnpm dev.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added support for `--tailscale` flag when starting the development server.

* **Chores**
  * Enhanced server startup configuration options.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->