### PR TITLE
Fix force-follow handling during scroll-to-bottom

### DIFF
--- a/apps/web/src/pages/SessionDetail/hooks/useScreenScroll.test.tsx
+++ b/apps/web/src/pages/SessionDetail/hooks/useScreenScroll.test.tsx
@@ -10,9 +10,9 @@ import { screenAtBottomAtom, screenForceFollowAtom } from "../atoms/screenAtoms"
 import { useScreenScroll } from "./useScreenScroll";
 
 describe("useScreenScroll", () => {
-  const createWrapper = () => {
+  const createWrapper = (initialAtBottom = true) => {
     const store = createStore();
-    store.set(screenAtBottomAtom, true);
+    store.set(screenAtBottomAtom, initialAtBottom);
     store.set(screenForceFollowAtom, false);
     return ({ children }: { children: ReactNode }) => (
       <JotaiProvider store={store}>{children}</JotaiProvider>
@@ -61,7 +61,7 @@ describe("useScreenScroll", () => {
     const onFlushPending = vi.fn();
     const onClearPending = vi.fn();
 
-    const wrapper = createWrapper();
+    const wrapper = createWrapper(false);
     const { result } = renderHook(
       () =>
         useScreenScroll({
@@ -102,6 +102,45 @@ describe("useScreenScroll", () => {
 
     expect(result.current.forceFollow).toBe(false);
     expect(onFlushPending).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not enable force follow when already at bottom", () => {
+    vi.useFakeTimers();
+    const isUserScrollingRef = { current: false };
+    const onFlushPending = vi.fn();
+    const onClearPending = vi.fn();
+
+    const wrapper = createWrapper(true);
+    const { result } = renderHook(
+      () =>
+        useScreenScroll({
+          mode: "text",
+          screenLinesLength: 2,
+          isUserScrollingRef,
+          onFlushPending,
+          onClearPending,
+        }),
+      { wrapper },
+    );
+
+    act(() => {
+      result.current.virtuosoRef.current = {
+        scrollToIndex: vi.fn(),
+      } as unknown as typeof result.current.virtuosoRef.current;
+      result.current.scrollerRef.current = {
+        scrollTo: vi.fn(),
+        scrollHeight: 200,
+      } as unknown as HTMLDivElement;
+      result.current.scrollToBottom("auto");
+    });
+
+    expect(result.current.forceFollow).toBe(false);
+
+    act(() => {
+      vi.advanceTimersByTime(5000);
+    });
+
+    expect(result.current.forceFollow).toBe(false);
   });
 
   it("clears pending on image mode and snaps on image->text", () => {

--- a/apps/web/src/pages/SessionDetail/hooks/useScreenScroll.ts
+++ b/apps/web/src/pages/SessionDetail/hooks/useScreenScroll.ts
@@ -44,14 +44,17 @@ export const useScreenScroll = ({
       if (!virtuosoRef.current || screenLinesLength === 0) return;
       const index = screenLinesLength - 1;
       virtuosoRef.current.scrollToIndex({ index, align: "end", behavior });
-      setForceFollow(true);
-      if (forceFollowTimerRef.current != null) {
-        window.clearTimeout(forceFollowTimerRef.current);
-      }
-      forceFollowTimerRef.current = window.setTimeout(() => {
+      if (isAtBottom) {
         stopForceFollow();
-        forceFollowTimerRef.current = null;
-      }, forceFollowFallbackMs);
+      } else {
+        setForceFollow(true);
+        if (forceFollowTimerRef.current != null) {
+          window.clearTimeout(forceFollowTimerRef.current);
+        }
+        forceFollowTimerRef.current = window.setTimeout(() => {
+          stopForceFollow();
+        }, forceFollowFallbackMs);
+      }
       window.requestAnimationFrame(() => {
         const scroller = scrollerRef.current;
         if (scroller) {
@@ -59,7 +62,7 @@ export const useScreenScroll = ({
         }
       });
     },
-    [forceFollowFallbackMs, screenLinesLength, setForceFollow, stopForceFollow],
+    [forceFollowFallbackMs, isAtBottom, screenLinesLength, setForceFollow, stopForceFollow],
   );
 
   const handleAtBottomChange = useCallback(


### PR DESCRIPTION
## Summary
- keep force-follow active while scroll-to-bottom is in progress
- stop force-follow when bottom is reached and centralize cleanup logic
- add fallback timeout to avoid stale follow state
- update hook test to verify force-follow is kept until bottom

## Verification
- pnpm test:run apps/web/src/pages/SessionDetail/hooks/useScreenScroll.test.tsx
- pnpm test:run apps/web/src/pages/SessionDetail/hooks/useStableVirtuosoScroll.test.tsx
- pnpm test:run apps/web/src/pages/SessionDetail/hooks/useSessionScreen.test.tsx
- pnpm eslint apps/web/src/pages/SessionDetail/hooks/useScreenScroll.ts apps/web/src/pages/SessionDetail/hooks/useScreenScroll.test.tsx