### PR TITLE
Implement smart wrap mode and line classification

### DIFF
--- a/apps/server/src/screen/screen-cache.ts
+++ b/apps/server/src/screen/screen-cache.ts
@@ -1,6 +1,6 @@
 import { randomUUID } from "node:crypto";
 
-import type { ScreenResponse } from "@vde-monitor/shared";
+import type { ScreenCaptureMeta, ScreenResponse } from "@vde-monitor/shared";
 
 import { nowIso } from "../http/helpers";
 import { buildScreenDeltas, shouldSendFull } from "../screen-diff";
@@ -18,6 +18,7 @@ type BuildTextResponseParams = {
   screen: string;
   alternateOn: boolean;
   truncated: boolean | null;
+  captureMeta?: ScreenCaptureMeta;
   cursor?: string;
   fallbackReason?: "image_failed" | "image_disabled";
 };
@@ -87,6 +88,7 @@ export const createScreenCache = (limit = 10): ScreenCache => {
     screen,
     alternateOn,
     truncated,
+    captureMeta,
     cursor,
     fallbackReason,
   }: BuildTextResponseParams): ScreenResponse => {
@@ -108,6 +110,7 @@ export const createScreenCache = (limit = 10): ScreenCache => {
       paneId,
       mode: "text",
       capturedAt: nowIso(),
+      captureMeta,
       lines: lineCount,
       truncated,
       alternateOn,

--- a/apps/server/src/screen/screen-response.test.ts
+++ b/apps/server/src/screen/screen-response.test.ts
@@ -50,6 +50,12 @@ describe("createScreenResponse", () => {
     });
 
     expect(response.ok).toBe(true);
+    expect(response.captureMeta).toMatchObject({
+      backend: "tmux",
+      lineModel: "joined-physical",
+      joinLinesApplied: true,
+      captureMethod: "tmux-capture-pane",
+    });
     expect(captureText).toHaveBeenCalledWith(
       expect.objectContaining({
         paneId: "%1",
@@ -166,6 +172,10 @@ describe("createScreenResponse", () => {
 
     expect(response.ok).toBe(false);
     expect(response.error?.code).toBe("RATE_LIMIT");
+    expect(response.captureMeta).toMatchObject({
+      captureMethod: "none",
+      lineModel: "none",
+    });
   });
 
   it("falls back to text when image mode is disabled", async () => {
@@ -247,6 +257,11 @@ describe("createScreenResponse", () => {
     expect(captureText).not.toHaveBeenCalled();
     expect(response.ok).toBe(true);
     expect(response.mode).toBe("image");
+    expect(response.captureMeta).toMatchObject({
+      backend: "wezterm",
+      captureMethod: "terminal-image",
+      lineModel: "none",
+    });
   });
 
   it("falls back to text when image capture fails", async () => {
@@ -302,5 +317,9 @@ describe("createScreenResponse", () => {
 
     expect(response.ok).toBe(false);
     expect(response.error?.code).toBe("INTERNAL");
+    expect(response.captureMeta).toMatchObject({
+      captureMethod: "none",
+      lineModel: "none",
+    });
   });
 });

--- a/apps/server/src/screen/screen-response.test.ts
+++ b/apps/server/src/screen/screen-response.test.ts
@@ -299,6 +299,7 @@ describe("createScreenResponse", () => {
         screen: {
           ...baseConfig.screen,
           image: { ...baseConfig.screen.image, enabled: false },
+          joinLines: true,
         },
       },
       monitor,
@@ -389,7 +390,11 @@ describe("createScreenResponse", () => {
     const response = await createScreenResponse({
       config: {
         ...baseConfig,
-        screen: { ...baseConfig.screen, image: { ...baseConfig.screen.image, enabled: true } },
+        screen: {
+          ...baseConfig.screen,
+          image: { ...baseConfig.screen.image, enabled: true },
+          joinLines: true,
+        },
       },
       monitor,
       target,

--- a/apps/server/src/screen/screen-response.test.ts
+++ b/apps/server/src/screen/screen-response.test.ts
@@ -15,7 +15,7 @@ vi.mock("../screen-service", () => ({
 }));
 
 describe("createScreenResponse", () => {
-  it("enables joinLines for claude sessions even when config is disabled", async () => {
+  it("follows config joinLines setting for claude sessions", async () => {
     const captureText = vi.fn(async () => ({
       screen: "hello",
       alternateOn: false,
@@ -52,15 +52,15 @@ describe("createScreenResponse", () => {
     expect(response.ok).toBe(true);
     expect(response.captureMeta).toMatchObject({
       backend: "tmux",
-      lineModel: "joined-physical",
-      joinLinesApplied: true,
+      lineModel: "physical",
+      joinLinesApplied: false,
       captureMethod: "tmux-capture-pane",
     });
     expect(captureText).toHaveBeenCalledWith(
       expect.objectContaining({
         paneId: "%1",
         lines: 5,
-        joinLines: true,
+        joinLines: false,
         includeTruncated: false,
       }),
     );

--- a/apps/server/src/screen/screen-response.ts
+++ b/apps/server/src/screen/screen-response.ts
@@ -26,8 +26,7 @@ type ScreenResponseParams = {
   buildTextResponse: ScreenCache["buildTextResponse"];
 };
 
-const resolveJoinLines = (config: AgentMonitorConfig, target: SessionDetail) =>
-  config.screen.joinLines || target.agent === "claude";
+const resolveJoinLines = (config: AgentMonitorConfig) => config.screen.joinLines;
 
 const resolveCaptureBackend = (config: AgentMonitorConfig): ScreenCaptureMeta["backend"] =>
   config.multiplexer.backend === "tmux" || config.multiplexer.backend === "wezterm"
@@ -98,7 +97,7 @@ export const createScreenResponse = async ({
 }: ScreenResponseParams): Promise<ScreenResponse> => {
   const lineCount = Math.min(lines ?? config.screen.defaultLines, config.screen.maxLines);
   const backend = resolveCaptureBackend(config);
-  const joinLinesApplied = resolveJoinLines(config, target);
+  const joinLinesApplied = resolveJoinLines(config);
   const textCaptureMeta = buildTextCaptureMeta({ backend, joinLinesApplied });
 
   const captureTextResponse = async (

--- a/apps/server/src/screen/screen-response.ts
+++ b/apps/server/src/screen/screen-response.ts
@@ -1,4 +1,9 @@
-import type { AgentMonitorConfig, ScreenResponse, SessionDetail } from "@vde-monitor/shared";
+import type {
+  AgentMonitorConfig,
+  ScreenCaptureMeta,
+  ScreenResponse,
+  SessionDetail,
+} from "@vde-monitor/shared";
 
 import { buildError, nowIso } from "../http/helpers";
 import type { createSessionMonitor } from "../monitor";
@@ -24,6 +29,55 @@ type ScreenResponseParams = {
 const resolveJoinLines = (config: AgentMonitorConfig, target: SessionDetail) =>
   config.screen.joinLines || target.agent === "claude";
 
+const resolveCaptureBackend = (config: AgentMonitorConfig): ScreenCaptureMeta["backend"] =>
+  config.multiplexer.backend === "tmux" || config.multiplexer.backend === "wezterm"
+    ? config.multiplexer.backend
+    : "unknown";
+
+const buildNoneCaptureMeta = (): ScreenCaptureMeta => ({
+  backend: "unknown",
+  lineModel: "none",
+  joinLinesApplied: null,
+  paneCols: null,
+  paneRows: null,
+  scrollbackRows: null,
+  captureMethod: "none",
+});
+
+const buildTextCaptureMeta = ({
+  backend,
+  joinLinesApplied,
+}: {
+  backend: ScreenCaptureMeta["backend"];
+  joinLinesApplied: boolean;
+}): ScreenCaptureMeta => ({
+  backend,
+  lineModel:
+    backend === "tmux"
+      ? joinLinesApplied
+        ? "joined-physical"
+        : "physical"
+      : backend === "wezterm"
+        ? "physical"
+        : "none",
+  joinLinesApplied,
+  paneCols: null,
+  paneRows: null,
+  scrollbackRows: null,
+  captureMethod:
+    backend === "tmux" ? "tmux-capture-pane" : backend === "wezterm" ? "wezterm-get-text" : "none",
+});
+
+const buildImageCaptureMeta = (backend: ScreenCaptureMeta["backend"]): ScreenCaptureMeta => ({
+  backend,
+  lineModel: "none",
+  joinLinesApplied: null,
+  paneCols: null,
+  paneRows: null,
+  scrollbackRows: null,
+  captureMethod: "terminal-image",
+});
+
 const resolveAltScreenMode = (config: AgentMonitorConfig, target: SessionDetail) => {
   if (isEditorCommand(target.currentCommand) || isEditorCommand(target.startCommand)) {
     return "on" as const;
@@ -43,6 +97,9 @@ export const createScreenResponse = async ({
   buildTextResponse,
 }: ScreenResponseParams): Promise<ScreenResponse> => {
   const lineCount = Math.min(lines ?? config.screen.defaultLines, config.screen.maxLines);
+  const backend = resolveCaptureBackend(config);
+  const joinLinesApplied = resolveJoinLines(config, target);
+  const textCaptureMeta = buildTextCaptureMeta({ backend, joinLinesApplied });
 
   const captureTextResponse = async (
     fallbackReason?: "image_failed" | "image_disabled",
@@ -52,7 +109,7 @@ export const createScreenResponse = async ({
       const text = await monitor.getScreenCapture().captureText({
         paneId: target.paneId,
         lines: lineCount,
-        joinLines: resolveJoinLines(config, target),
+        joinLines: joinLinesApplied,
         includeAnsi: config.screen.ansi,
         includeTruncated: config.screen.includeTruncated,
         altScreen: resolveAltScreenMode(config, target),
@@ -65,6 +122,7 @@ export const createScreenResponse = async ({
         screen: text.screen,
         alternateOn: text.alternateOn,
         truncated: text.truncated,
+        captureMeta: textCaptureMeta,
         cursor: applyCursor ? cursor : undefined,
         fallbackReason,
       });
@@ -74,6 +132,7 @@ export const createScreenResponse = async ({
         paneId: target.paneId,
         mode: "text",
         capturedAt: nowIso(),
+        captureMeta: buildNoneCaptureMeta(),
         error: buildError("INTERNAL", "screen capture failed"),
       };
     }
@@ -85,6 +144,7 @@ export const createScreenResponse = async ({
       paneId: target.paneId,
       mode: "text",
       capturedAt: nowIso(),
+      captureMeta: buildNoneCaptureMeta(),
       error: buildError("RATE_LIMIT", "rate limited"),
     };
   }
@@ -113,6 +173,7 @@ export const createScreenResponse = async ({
         paneId: target.paneId,
         mode: "image",
         capturedAt: nowIso(),
+        captureMeta: buildImageCaptureMeta(backend),
         imageBase64: imageResult.imageBase64,
         cropped: imageResult.cropped,
       };

--- a/apps/server/src/screen/screen-response.ts
+++ b/apps/server/src/screen/screen-response.ts
@@ -45,9 +45,6 @@ const buildNoneCaptureMeta = (): ScreenCaptureMeta => ({
   backend: "unknown",
   lineModel: "none",
   joinLinesApplied: null,
-  paneCols: null,
-  paneRows: null,
-  scrollbackRows: null,
   captureMethod: "none",
 });
 
@@ -57,31 +54,30 @@ const buildTextCaptureMeta = ({
 }: {
   backend: ScreenCaptureMeta["backend"];
   joinLinesApplied: boolean;
-}): ScreenCaptureMeta => ({
-  backend,
-  lineModel:
+}): ScreenCaptureMeta => {
+  const lineModel =
     backend === "tmux"
       ? joinLinesApplied
         ? "joined-physical"
         : "physical"
       : backend === "wezterm"
         ? "physical"
-        : "none",
-  joinLinesApplied,
-  paneCols: null,
-  paneRows: null,
-  scrollbackRows: null,
-  captureMethod:
-    backend === "tmux" ? "tmux-capture-pane" : backend === "wezterm" ? "wezterm-get-text" : "none",
-});
+        : "none";
+  const captureMethod =
+    backend === "tmux" ? "tmux-capture-pane" : backend === "wezterm" ? "wezterm-get-text" : "none";
+
+  return {
+    backend,
+    lineModel,
+    joinLinesApplied,
+    captureMethod,
+  };
+};
 
 const buildImageCaptureMeta = (backend: ScreenCaptureMeta["backend"]): ScreenCaptureMeta => ({
   backend,
   lineModel: "none",
   joinLinesApplied: null,
-  paneCols: null,
-  paneRows: null,
-  scrollbackRows: null,
   captureMethod: "terminal-image",
 });
 

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -268,11 +268,11 @@ body::before {
 .vde-screen-line-smart {
   white-space: pre-wrap;
   overflow-wrap: anywhere;
-  word-break: break-word;
 }
 
 .vde-smart-wrap-hang {
   --vde-wrap-indent-ch: 0ch;
+
   display: block;
   padding-left: var(--vde-wrap-indent-ch);
   text-indent: calc(var(--vde-wrap-indent-ch) * -1);

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -265,6 +265,41 @@ body::before {
   text-align: right;
 }
 
+.vde-screen-line-smart {
+  white-space: pre-wrap;
+  overflow-wrap: anywhere;
+  word-break: break-word;
+}
+
+.vde-smart-wrap-hang {
+  --vde-wrap-indent-ch: 0ch;
+  display: block;
+  padding-left: var(--vde-wrap-indent-ch);
+  text-indent: calc(var(--vde-wrap-indent-ch) * -1);
+  white-space: inherit;
+}
+
+.vde-smart-wrap-preserve-row,
+.vde-smart-wrap-statusline,
+.vde-smart-wrap-diff-block,
+.vde-smart-wrap-claude-block {
+  display: block;
+  min-width: max-content;
+  white-space: pre;
+  overflow-wrap: normal;
+  word-break: normal;
+}
+
+.vde-smart-wrap-divider {
+  max-width: 100%;
+  display: block;
+  white-space: pre;
+  overflow-wrap: normal;
+  word-break: normal;
+  overflow: hidden;
+  text-overflow: clip;
+}
+
 @keyframes pulse-soft {
   0%,
   100% {

--- a/apps/web/src/lib/ansi.test.ts
+++ b/apps/web/src/lib/ansi.test.ts
@@ -159,20 +159,26 @@ describe("renderAnsiLines", () => {
   it("formats Claude Write output code lines as added diff lines", () => {
     const text = [
       "Write(ai/tmp/sample.ts)",
-      "└ Wrote 5 lines to ai/tmp/sample.ts",
+      "└ Wrote 9 lines to ai/tmp/sample.ts",
       "1 type User = {",
       "2   id: number",
       "3   name: string",
-      "4 }",
-      "5 ",
+      "4   email: string",
+      "5 }",
+      "6",
+      "7 const greet = (user: User): string => {",
+      "8   return `Hello, ${user.name}! Your email is ${user.email}.`",
+      "9 }",
       "... +3 lines (ctrl+o to expand)",
     ].join("\n");
     const lines = renderAnsiLines(text, "latte", { agent: "claude" });
     expect(lines[2]).toContain('class="text-latte-green"');
     expect(lines[2]).toContain(">+type User = {<");
     expect(lines[3]).toContain(">+  id: number<");
-    expect(lines[6]).toContain(">+<");
-    expect(lines[7]).not.toContain('class="text-latte-green"');
+    expect(lines[7]).toContain(">+<");
+    expect(lines[8]).toContain(">+const greet = (user: User): string =&gt; {<");
+    expect(lines[9]).toContain(">+  return `Hello, ${user.name}! Your email is ${user.email}.`<");
+    expect(lines[11]).not.toContain('class="text-latte-green"');
   });
 
   it("strips ANSI codes and escapes HTML in Claude diff rendering", () => {

--- a/apps/web/src/lib/ansi.ts
+++ b/apps/web/src/lib/ansi.ts
@@ -236,7 +236,7 @@ const normalizeCodexBackgrounds = (
 };
 
 const claudeWriteSummaryPattern = /\bWrote\s+\d+\s+lines?\s+to\b/i;
-const claudeWriteLinePattern = /^(\s*)(\d+)(\s+)(.*)$/;
+const claudeWriteLinePattern = /^(\s*)(\d+)(?:([ \t]+)(.*))?$/;
 
 const addClaudeWriteDiffMarker = (line: string) => {
   const match = line.match(claudeWriteLinePattern);
@@ -246,6 +246,9 @@ const addClaudeWriteDiffMarker = (line: string) => {
   const [, leading = "", lineNo = "", separator = "", content = ""] = match;
   if (content.startsWith("+") || content.startsWith("-")) {
     return line;
+  }
+  if (!separator) {
+    return `${leading}${lineNo} +`;
   }
   const [lineSeparator = " ", ...indentChars] = separator;
   const indentation = indentChars.join("");

--- a/apps/web/src/lib/clipboard.test.ts
+++ b/apps/web/src/lib/clipboard.test.ts
@@ -12,4 +12,9 @@ describe("sanitizeLogCopyText", () => {
     const input = "line1\r\nline2\rline3\u200B";
     expect(sanitizeLogCopyText(input)).toBe("line1\nline2\nline3");
   });
+
+  it("normalizes non-breaking spaces", () => {
+    const input = "-\u00A0long-token";
+    expect(sanitizeLogCopyText(input)).toBe("- long-token");
+  });
 });

--- a/apps/web/src/lib/clipboard.ts
+++ b/apps/web/src/lib/clipboard.ts
@@ -1,4 +1,5 @@
 const zeroWidthPattern = /[\u200B\uFEFF]/g;
+const nonBreakingSpacePattern = /\u00A0/g;
 
 const isFilteredControlCode = (code: number) => {
   const isC0Control = code <= 0x1f && code !== 0x09 && code !== 0x0a;
@@ -11,6 +12,7 @@ export const sanitizeLogCopyText = (value: string): string => {
   const normalized = value
     .replace(/\r\n/g, "\n")
     .replace(/\r/g, "\n")
+    .replace(nonBreakingSpacePattern, " ")
     .replace(zeroWidthPattern, "");
   let result = "";
   for (let index = 0; index < normalized.length; index += 1) {

--- a/apps/web/src/pages/SessionDetail/SessionDetailView.test.tsx
+++ b/apps/web/src/pages/SessionDetail/SessionDetailView.test.tsx
@@ -115,6 +115,7 @@ const createViewProps = (overrides: SessionDetailViewOverrides = {}): SessionDet
     },
     screen: {
       mode: "text",
+      wrapMode: "off",
       screenLines: [],
       imageBase64: null,
       fallbackReason: null,
@@ -128,6 +129,7 @@ const createViewProps = (overrides: SessionDetailViewOverrides = {}): SessionDet
       forceFollow: false,
       scrollToBottom: vi.fn(),
       handleModeChange: vi.fn(),
+      toggleWrapMode: vi.fn(),
       virtuosoRef: { current: null } as MutableRefObject<VirtuosoHandle | null>,
       scrollerRef: { current: null } as MutableRefObject<HTMLDivElement | null>,
       handleRefreshScreen: vi.fn(),

--- a/apps/web/src/pages/SessionDetail/atoms/screenAtoms.ts
+++ b/apps/web/src/pages/SessionDetail/atoms/screenAtoms.ts
@@ -14,6 +14,9 @@ import {
 } from "./sessionDetailAtoms";
 
 export const screenModeAtom = atom<ScreenMode>("text");
+export type ScreenWrapMode = "off" | "smart";
+
+export const screenWrapModeAtom = atom<ScreenWrapMode>("off");
 export const screenModeLoadedAtom = atom({ text: false, image: false });
 export const screenAtBottomAtom = atom(true);
 export const screenForceFollowAtom = atom(false);

--- a/apps/web/src/pages/SessionDetail/components/ScreenPanel.test.tsx
+++ b/apps/web/src/pages/SessionDetail/components/ScreenPanel.test.tsx
@@ -87,12 +87,12 @@ describe("ScreenPanel", () => {
     expect(screen.getByText("Unsafe")).toBeTruthy();
   });
 
-  it("shows smart wrap button next to refresh", () => {
+  it("shows wrap button next to refresh", () => {
     const state = buildState();
     const actions = buildActions();
     render(<ScreenPanel state={state} actions={actions} controls={null} />);
 
-    const smartButton = screen.getByRole("button", { name: "Toggle smart wrap" });
+    const smartButton = screen.getByRole("button", { name: "Toggle wrap mode" });
     const refreshButton = screen.getByRole("button", { name: "Refresh screen" });
     expect(smartButton).toBeTruthy();
     expect(refreshButton).toBeTruthy();
@@ -101,11 +101,11 @@ describe("ScreenPanel", () => {
     ).not.toBe(0);
   });
 
-  it("disables smart wrap button in image mode", () => {
+  it("disables wrap button in image mode", () => {
     const state = buildState({ mode: "image" });
     const actions = buildActions();
     render(<ScreenPanel state={state} actions={actions} controls={null} />);
-    const smartButton = screen.getByRole("button", { name: "Toggle smart wrap" });
+    const smartButton = screen.getByRole("button", { name: "Toggle wrap mode" });
     expect(smartButton.getAttribute("disabled")).not.toBeNull();
   });
 

--- a/apps/web/src/pages/SessionDetail/components/ScreenPanel.test.tsx
+++ b/apps/web/src/pages/SessionDetail/components/ScreenPanel.test.tsx
@@ -26,6 +26,10 @@ describe("ScreenPanel", () => {
 
   const buildState = (overrides: Partial<ScreenPanelState> = {}): ScreenPanelState => ({
     mode: "text",
+    wrapMode: "off",
+    paneId: "pane-1",
+    sourceRepoRoot: "/repo",
+    agent: "codex",
     connectionIssue: null,
     fallbackReason: null,
     error: null,
@@ -64,6 +68,7 @@ describe("ScreenPanel", () => {
 
   const buildActions = (overrides: Partial<ScreenPanelActions> = {}): ScreenPanelActions => ({
     onModeChange: vi.fn(),
+    onToggleWrapMode: vi.fn(),
     onRefresh: vi.fn(),
     onAtBottomChange: vi.fn(),
     onScrollToBottom: vi.fn(),
@@ -80,6 +85,45 @@ describe("ScreenPanel", () => {
 
     expect(screen.getByText("Raw")).toBeTruthy();
     expect(screen.getByText("Unsafe")).toBeTruthy();
+  });
+
+  it("shows smart wrap button next to refresh", () => {
+    const state = buildState();
+    const actions = buildActions();
+    render(<ScreenPanel state={state} actions={actions} controls={null} />);
+
+    const smartButton = screen.getByRole("button", { name: "Toggle smart wrap" });
+    const refreshButton = screen.getByRole("button", { name: "Refresh screen" });
+    expect(smartButton).toBeTruthy();
+    expect(refreshButton).toBeTruthy();
+    expect(
+      smartButton.compareDocumentPosition(refreshButton) & Node.DOCUMENT_POSITION_FOLLOWING,
+    ).not.toBe(0);
+  });
+
+  it("disables smart wrap button in image mode", () => {
+    const state = buildState({ mode: "image" });
+    const actions = buildActions();
+    render(<ScreenPanel state={state} actions={actions} controls={null} />);
+    const smartButton = screen.getByRole("button", { name: "Toggle smart wrap" });
+    expect(smartButton.getAttribute("disabled")).not.toBeNull();
+  });
+
+  it("uses non-virtualized rendering path when smart wrap is enabled", () => {
+    const state = buildState({
+      wrapMode: "smart",
+      mode: "text",
+      screenLines: ["- supercalifragilisticexpialidocious token"],
+    });
+    const actions = buildActions();
+    render(<ScreenPanel state={state} actions={actions} controls={null} />);
+    expect(screen.queryByTestId("virtuoso")).toBeNull();
+    expect(screen.getByText(/supercalifragilisticexpialidocious/)).toBeTruthy();
+    const smartScroller = screen.getByTestId("smart-screen-scroller");
+    expect(smartScroller.getAttribute("style")).toContain("60vh");
+    const smartLines = screen.getByTestId("smart-screen-lines");
+    expect(smartLines.className).toContain("w-full");
+    expect(smartLines.className).not.toContain("w-max");
   });
 
   it("renders fallback and error messages", () => {
@@ -1000,10 +1044,11 @@ describe("ScreenPanel", () => {
     });
   });
 
-  it("re-resolves candidates when resolver callback changes", async () => {
+  it("re-resolves candidates when context key changes", async () => {
     const initialResolver = vi.fn(async () => []);
     const nextResolver = vi.fn(async (rawTokens: string[]) => rawTokens);
     const state = buildState({
+      paneId: "pane-1",
       screenLines: ["src/main.ts:1"],
     });
     const actions = buildActions({ onResolveFileReferenceCandidates: initialResolver });
@@ -1018,7 +1063,7 @@ describe("ScreenPanel", () => {
 
     rerender(
       <ScreenPanel
-        state={state}
+        state={{ ...state, paneId: "pane-2" }}
         actions={buildActions({ onResolveFileReferenceCandidates: nextResolver })}
         controls={null}
       />,
@@ -1095,6 +1140,7 @@ describe("ScreenPanel", () => {
     const { container, rerender } = render(
       <ScreenPanel
         state={buildState({
+          paneId: "pane-1",
           screenLines: ["└ Read SessionDetailView.test.tsx, useSessionDetailVM.test.tsx"],
         })}
         actions={actions}
@@ -1114,6 +1160,7 @@ describe("ScreenPanel", () => {
     rerender(
       <ScreenPanel
         state={buildState({
+          paneId: "pane-2",
           screenLines: [
             "• Explored",
             "└ Read SessionDetailView.test.tsx, useSessionDetailVM.test.tsx",

--- a/apps/web/src/pages/SessionDetail/components/ScreenPanel.tsx
+++ b/apps/web/src/pages/SessionDetail/components/ScreenPanel.tsx
@@ -92,8 +92,6 @@ type ScreenPanelProps = {
   controls: ReactNode;
 };
 
-const SMART_RENDER_LINE_SOFT_LIMIT = 3000;
-
 const shouldShowErrorMessage = (error: string | null, connectionIssue: string | null) =>
   Boolean(error) &&
   (!connectionIssue || (error !== connectionIssue && error !== DISCONNECTED_MESSAGE));
@@ -234,12 +232,8 @@ export const ScreenPanel = ({ state, actions, controls }: ScreenPanelProps) => {
     onResolveFileReferenceCandidates,
   } = actions;
   const showError = shouldShowErrorMessage(error, connectionIssue);
-  const smartRenderFallbackReason =
-    mode === "text" && wrapMode === "smart" && screenLines.length > SMART_RENDER_LINE_SOFT_LIMIT
-      ? `Smart wrap is temporarily disabled for large output (${screenLines.length} lines > ${SMART_RENDER_LINE_SOFT_LIMIT}).`
-      : null;
   const effectiveWrapMode: ScreenWrapMode =
-    mode === "text" && wrapMode === "smart" && smartRenderFallbackReason == null ? "smart" : "off";
+    mode === "text" && wrapMode === "smart" ? "smart" : "off";
   const pollingPauseMeta = pollingPauseReason ? pollingPauseLabelMap[pollingPauseReason] : null;
   const gitBranchLabel = formatBranchLabel(promptGitContext?.branch);
   const gitFileChanges = promptGitContext?.fileChanges;
@@ -405,11 +399,6 @@ export const ScreenPanel = ({ state, actions, controls }: ScreenPanelProps) => {
       {fallbackReason && (
         <Callout tone="warning" size="xs">
           Image fallback: {fallbackReason}
-        </Callout>
-      )}
-      {smartRenderFallbackReason && (
-        <Callout tone="warning" size="xs">
-          {smartRenderFallbackReason}
         </Callout>
       )}
       {showError && (

--- a/apps/web/src/pages/SessionDetail/components/ScreenPanel.tsx
+++ b/apps/web/src/pages/SessionDetail/components/ScreenPanel.tsx
@@ -16,11 +16,13 @@ import { Button, Callout, Card, Tabs, TabsList, TabsTrigger, Toolbar } from "@/c
 import { cn } from "@/lib/cn";
 import type { ScreenMode } from "@/lib/screen-loading";
 
+import type { ScreenWrapMode } from "../atoms/screenAtoms";
 import { usePromptContextLayout } from "../hooks/usePromptContextLayout";
 import { useScreenPanelLogReferenceLinking } from "../hooks/useScreenPanelLogReferenceLinking";
 import { useScreenPanelWorktreeSelector } from "../hooks/useScreenPanelWorktreeSelector";
 import { useStableVirtuosoScroll } from "../hooks/useStableVirtuosoScroll";
 import { DISCONNECTED_MESSAGE, formatBranchLabel } from "../sessionDetailUtils";
+import { classifySmartWrapLines } from "../smart-wrap-classify";
 import { ScreenPanelPromptContext } from "./screen-panel-prompt-context";
 import { ScreenPanelViewport } from "./ScreenPanelViewport";
 import {
@@ -31,6 +33,10 @@ import {
 
 type ScreenPanelState = {
   mode: ScreenMode;
+  wrapMode: ScreenWrapMode;
+  paneId: string;
+  sourceRepoRoot: string | null;
+  agent: "codex" | "claude" | "unknown";
   connectionIssue: string | null;
   fallbackReason: string | null;
   error: string | null;
@@ -68,6 +74,7 @@ type ScreenPanelState = {
 
 type ScreenPanelActions = {
   onModeChange: (mode: ScreenMode) => void;
+  onToggleWrapMode: () => void;
   onRefresh: () => void;
   onRefreshWorktrees?: () => void;
   onAtBottomChange: (value: boolean) => void;
@@ -84,6 +91,8 @@ type ScreenPanelProps = {
   actions: ScreenPanelActions;
   controls: ReactNode;
 };
+
+const SMART_RENDER_LINE_SOFT_LIMIT = 3000;
 
 const shouldShowErrorMessage = (error: string | null, connectionIssue: string | null) =>
   Boolean(error) &&
@@ -182,6 +191,10 @@ const RawModeIndicator = ({
 export const ScreenPanel = ({ state, actions, controls }: ScreenPanelProps) => {
   const {
     mode,
+    wrapMode,
+    paneId,
+    sourceRepoRoot,
+    agent,
     connectionIssue,
     fallbackReason,
     error,
@@ -209,6 +222,7 @@ export const ScreenPanel = ({ state, actions, controls }: ScreenPanelProps) => {
   } = state;
   const {
     onModeChange,
+    onToggleWrapMode,
     onRefresh,
     onRefreshWorktrees,
     onAtBottomChange,
@@ -220,6 +234,12 @@ export const ScreenPanel = ({ state, actions, controls }: ScreenPanelProps) => {
     onResolveFileReferenceCandidates,
   } = actions;
   const showError = shouldShowErrorMessage(error, connectionIssue);
+  const smartRenderFallbackReason =
+    mode === "text" && wrapMode === "smart" && screenLines.length > SMART_RENDER_LINE_SOFT_LIMIT
+      ? `Smart wrap is temporarily disabled for large output (${screenLines.length} lines > ${SMART_RENDER_LINE_SOFT_LIMIT}).`
+      : null;
+  const effectiveWrapMode: ScreenWrapMode =
+    mode === "text" && wrapMode === "smart" && smartRenderFallbackReason == null ? "smart" : "off";
   const pollingPauseMeta = pollingPauseReason ? pollingPauseLabelMap[pollingPauseReason] : null;
   const gitBranchLabel = formatBranchLabel(promptGitContext?.branch);
   const gitFileChanges = promptGitContext?.fileChanges;
@@ -272,13 +292,24 @@ export const ScreenPanel = ({ state, actions, controls }: ScreenPanelProps) => {
   const { scrollerRef: stableScrollerRef, handleRangeChanged } = useStableVirtuosoScroll({
     items: screenLines,
     isAtBottom,
-    enabled: mode === "text",
+    enabled: mode === "text" && effectiveWrapMode === "off",
     scrollerRef,
     isUserScrolling: forceFollow,
     onUserScrollStateChange,
   });
+  const smartLineClassifications = useMemo(
+    () =>
+      mode === "text" && effectiveWrapMode === "smart"
+        ? classifySmartWrapLines(screenLines, agent)
+        : [],
+    [agent, effectiveWrapMode, mode, screenLines],
+  );
   const { linkifiedScreenLines, handleScreenRangeChanged } = useScreenPanelLogReferenceLinking({
     mode,
+    effectiveWrapMode,
+    paneId,
+    sourceRepoRoot,
+    agent,
     screenLines,
     onResolveFileReferenceCandidates,
     onRangeChanged: handleRangeChanged,
@@ -349,6 +380,17 @@ export const ScreenPanel = ({ state, actions, controls }: ScreenPanelProps) => {
         <div className="flex items-center gap-2">
           <RawModeIndicator rawMode={rawMode} allowDangerKeys={allowDangerKeys} />
           <Button
+            variant={wrapMode === "smart" ? "primary" : "ghost"}
+            size="sm"
+            className="h-[30px] px-2 text-[10px] font-semibold uppercase tracking-[0.24em]"
+            onClick={onToggleWrapMode}
+            disabled={mode === "image"}
+            aria-label="Toggle smart wrap"
+            aria-pressed={wrapMode === "smart"}
+          >
+            Smart
+          </Button>
+          <Button
             variant="ghost"
             size="sm"
             className="text-latte-subtext0 hover:text-latte-text h-[30px] w-[30px] p-0"
@@ -365,6 +407,11 @@ export const ScreenPanel = ({ state, actions, controls }: ScreenPanelProps) => {
           Image fallback: {fallbackReason}
         </Callout>
       )}
+      {smartRenderFallbackReason && (
+        <Callout tone="warning" size="xs">
+          {smartRenderFallbackReason}
+        </Callout>
+      )}
       {showError && (
         <Callout tone="error" size="xs">
           {error}
@@ -377,15 +424,19 @@ export const ScreenPanel = ({ state, actions, controls }: ScreenPanelProps) => {
       )}
       <ScreenPanelViewport
         mode={mode}
+        effectiveWrapMode={effectiveWrapMode}
         imageBase64={imageBase64}
         isAtBottom={isAtBottom}
         isScreenLoading={isScreenLoading}
         screenLines={linkifiedScreenLines}
+        smartLineClassifications={smartLineClassifications}
         virtuosoRef={virtuosoRef}
+        scrollerRef={scrollerRef}
         onAtBottomChange={onAtBottomChange}
         onRangeChanged={handleScreenRangeChanged}
         VirtuosoScroller={VirtuosoScroller}
         onScrollToBottom={onScrollToBottom}
+        onUserScrollStateChange={onUserScrollStateChange}
         onResolveFileReference={handleResolveFileReference}
         onResolveFileReferenceKeyDown={handleResolveFileReferenceKeyDown}
       />

--- a/apps/web/src/pages/SessionDetail/components/ScreenPanel.tsx
+++ b/apps/web/src/pages/SessionDetail/components/ScreenPanel.tsx
@@ -1,5 +1,5 @@
 import type { WorktreeListEntry } from "@vde-monitor/shared";
-import { FileText, Image, RefreshCw } from "lucide-react";
+import { FileText, Image, RefreshCw, TextWrap } from "lucide-react";
 import {
   forwardRef,
   type HTMLAttributes,
@@ -379,10 +379,10 @@ export const ScreenPanel = ({ state, actions, controls }: ScreenPanelProps) => {
             className="h-[30px] px-2 text-[10px] font-semibold uppercase tracking-[0.24em]"
             onClick={onToggleWrapMode}
             disabled={mode === "image"}
-            aria-label="Toggle smart wrap"
+            aria-label="Toggle wrap mode"
             aria-pressed={wrapMode === "smart"}
           >
-            Smart
+            <TextWrap className="h-3.5 w-3.5" />
           </Button>
           <Button
             variant="ghost"

--- a/apps/web/src/pages/SessionDetail/components/ScreenPanelViewport.tsx
+++ b/apps/web/src/pages/SessionDetail/components/ScreenPanelViewport.tsx
@@ -12,34 +12,48 @@ import { AnsiVirtualizedViewport } from "@/features/shared-session-ui/components
 import { sanitizeLogCopyText } from "@/lib/clipboard";
 import type { ScreenMode } from "@/lib/screen-loading";
 
+import type { ScreenWrapMode } from "../atoms/screenAtoms";
+import type { SmartWrapLineClassification } from "../smart-wrap-classify";
+import { SmartScreenViewport } from "./SmartScreenViewport";
+
+const SCREEN_VIEWPORT_HEIGHT = "60vh";
+
 type ScreenPanelViewportProps = {
   mode: ScreenMode;
+  effectiveWrapMode: ScreenWrapMode;
   imageBase64: string | null;
   isAtBottom: boolean;
   isScreenLoading: boolean;
   screenLines: string[];
+  smartLineClassifications: SmartWrapLineClassification[];
   virtuosoRef: RefObject<VirtuosoHandle | null>;
+  scrollerRef: RefObject<HTMLDivElement | null>;
   onAtBottomChange: (value: boolean) => void;
   onRangeChanged: (range: { startIndex: number; endIndex: number }) => void;
   VirtuosoScroller: (
     props: HTMLAttributes<HTMLDivElement> & { ref?: React.Ref<HTMLDivElement> },
   ) => ReactNode;
   onScrollToBottom: (behavior: "auto" | "smooth") => void;
+  onUserScrollStateChange: (value: boolean) => void;
   onResolveFileReference: (event: MouseEvent<HTMLDivElement>) => void;
   onResolveFileReferenceKeyDown: (event: KeyboardEvent<HTMLDivElement>) => void;
 };
 
 export const ScreenPanelViewport = ({
   mode,
+  effectiveWrapMode,
   imageBase64,
   isAtBottom,
   isScreenLoading,
   screenLines,
+  smartLineClassifications,
   virtuosoRef,
+  scrollerRef,
   onAtBottomChange,
   onRangeChanged,
   VirtuosoScroller,
   onScrollToBottom,
+  onUserScrollStateChange,
   onResolveFileReference,
   onResolveFileReferenceKeyDown,
 }: ScreenPanelViewportProps) => {
@@ -60,6 +74,27 @@ export const ScreenPanelViewport = ({
     );
   }
 
+  if (effectiveWrapMode === "smart") {
+    return (
+      <SmartScreenViewport
+        lines={screenLines}
+        classifications={smartLineClassifications}
+        loading={isScreenLoading}
+        loadingLabel="Loading screen..."
+        isAtBottom={isAtBottom}
+        onAtBottomChange={onAtBottomChange}
+        onRangeChanged={onRangeChanged}
+        scrollerRef={scrollerRef}
+        onScrollToBottom={onScrollToBottom}
+        onUserScrollStateChange={onUserScrollStateChange}
+        sanitizeCopyText={sanitizeLogCopyText}
+        onLineClick={onResolveFileReference}
+        onLineKeyDown={onResolveFileReferenceKeyDown}
+        height={SCREEN_VIEWPORT_HEIGHT}
+      />
+    );
+  }
+
   return (
     <AnsiVirtualizedViewport
       lines={screenLines}
@@ -75,7 +110,7 @@ export const ScreenPanelViewport = ({
       viewportClassName="w-full min-w-0 max-w-full"
       listClassName="text-latte-text w-max min-w-full px-1 py-1 font-mono text-xs sm:px-2 sm:py-2"
       lineClassName="min-h-4 whitespace-pre leading-4"
-      height="60vh"
+      height={SCREEN_VIEWPORT_HEIGHT}
       sanitizeCopyText={sanitizeLogCopyText}
       onLineClick={onResolveFileReference}
       onLineKeyDown={onResolveFileReferenceKeyDown}

--- a/apps/web/src/pages/SessionDetail/components/SmartScreenViewport.tsx
+++ b/apps/web/src/pages/SessionDetail/components/SmartScreenViewport.tsx
@@ -155,6 +155,9 @@ export const SmartScreenViewport = ({
               className={cn("vde-screen-line-smart min-h-4 leading-4", line.className)}
               onClick={onLineClick}
               onKeyDown={onLineKeyDown}
+              // lineHtml must come from the controlled screen pipeline
+              // (server terminal output -> ansi escape -> DOM-only transforms),
+              // never from unvalidated user input.
               dangerouslySetInnerHTML={{ __html: line.lineHtml || "&#x200B;" }}
             />
           ))}

--- a/apps/web/src/pages/SessionDetail/components/SmartScreenViewport.tsx
+++ b/apps/web/src/pages/SessionDetail/components/SmartScreenViewport.tsx
@@ -148,6 +148,7 @@ export const SmartScreenViewport = ({
       >
         <div
           data-testid="smart-screen-lines"
+          role="log"
           className="text-latte-text w-full min-w-full max-w-full px-1 py-1 font-mono text-xs sm:px-2 sm:py-2"
           onClick={onLineClick}
           onKeyDown={onLineKeyDown}

--- a/apps/web/src/pages/SessionDetail/components/SmartScreenViewport.tsx
+++ b/apps/web/src/pages/SessionDetail/components/SmartScreenViewport.tsx
@@ -1,0 +1,177 @@
+import { ArrowDown } from "lucide-react";
+import {
+  type ClipboardEvent,
+  type KeyboardEvent,
+  type MouseEvent,
+  type RefObject,
+  type UIEvent,
+  useCallback,
+  useEffect,
+  useLayoutEffect,
+  useMemo,
+  useRef,
+} from "react";
+
+import { IconButton, LoadingOverlay } from "@/components/ui";
+import { cn } from "@/lib/cn";
+
+import type { SmartWrapLineClassification } from "../smart-wrap-classify";
+import { decorateSmartWrapLines } from "../smart-wrap-decorator";
+
+type SmartScreenViewportProps = {
+  lines: string[];
+  classifications: SmartWrapLineClassification[];
+  loading: boolean;
+  loadingLabel: string;
+  isAtBottom: boolean;
+  onAtBottomChange: (value: boolean) => void;
+  onRangeChanged: (range: { startIndex: number; endIndex: number }) => void;
+  scrollerRef: RefObject<HTMLDivElement | null>;
+  onScrollToBottom: (behavior: "auto" | "smooth") => void;
+  onUserScrollStateChange: (value: boolean) => void;
+  sanitizeCopyText: (raw: string) => string;
+  onLineClick: (event: MouseEvent<HTMLDivElement>) => void;
+  onLineKeyDown: (event: KeyboardEvent<HTMLDivElement>) => void;
+  height?: string | number;
+};
+
+const resolveIsAtBottom = (node: HTMLDivElement) =>
+  node.scrollHeight - (node.scrollTop + node.clientHeight) <= 2;
+
+export const SmartScreenViewport = ({
+  lines,
+  classifications,
+  loading,
+  loadingLabel,
+  isAtBottom,
+  onAtBottomChange,
+  onRangeChanged,
+  scrollerRef,
+  onScrollToBottom,
+  onUserScrollStateChange,
+  sanitizeCopyText,
+  onLineClick,
+  onLineKeyDown,
+  height = "100%",
+}: SmartScreenViewportProps) => {
+  const scrollEndTimerRef = useRef<number | null>(null);
+  const decoratedLines = useMemo(
+    () => decorateSmartWrapLines(lines, classifications),
+    [classifications, lines],
+  );
+
+  useEffect(() => {
+    if (lines.length === 0) {
+      return;
+    }
+    onRangeChanged({ startIndex: 0, endIndex: lines.length - 1 });
+  }, [lines.length, onRangeChanged]);
+
+  useLayoutEffect(() => {
+    if (!isAtBottom) {
+      return;
+    }
+    const node = scrollerRef.current;
+    if (!node) {
+      return;
+    }
+    node.scrollTop = node.scrollHeight;
+  }, [decoratedLines, isAtBottom, scrollerRef]);
+
+  useEffect(() => {
+    const node = scrollerRef.current;
+    if (!node) {
+      return;
+    }
+    onAtBottomChange(resolveIsAtBottom(node));
+  }, [decoratedLines, onAtBottomChange, scrollerRef]);
+
+  useEffect(
+    () => () => {
+      if (scrollEndTimerRef.current != null) {
+        window.clearTimeout(scrollEndTimerRef.current);
+      }
+    },
+    [],
+  );
+
+  const handleCopy = useCallback(
+    (event: ClipboardEvent<HTMLDivElement>) => {
+      const selection = window.getSelection?.();
+      const raw = selection?.toString() ?? "";
+      if (!raw) {
+        return;
+      }
+      const sanitized = sanitizeCopyText(raw);
+      if (!event.clipboardData || sanitized === raw) {
+        return;
+      }
+      event.preventDefault();
+      event.clipboardData.setData("text/plain", sanitized);
+    },
+    [sanitizeCopyText],
+  );
+
+  const handleScroll = useCallback(
+    (event: UIEvent<HTMLDivElement>) => {
+      const node = event.currentTarget;
+      onAtBottomChange(resolveIsAtBottom(node));
+      if (!event.isTrusted) {
+        return;
+      }
+      onUserScrollStateChange(true);
+      if (scrollEndTimerRef.current != null) {
+        window.clearTimeout(scrollEndTimerRef.current);
+      }
+      scrollEndTimerRef.current = window.setTimeout(() => {
+        onUserScrollStateChange(false);
+        scrollEndTimerRef.current = null;
+      }, 120);
+    },
+    [onAtBottomChange, onUserScrollStateChange],
+  );
+
+  return (
+    <div
+      className="border-latte-surface2/80 bg-latte-crust/95 shadow-inner-soft relative min-h-[260px] w-full min-w-0 max-w-full flex-1 rounded-2xl border-2 sm:min-h-[320px]"
+      onCopy={handleCopy}
+    >
+      {loading && <LoadingOverlay label={loadingLabel} />}
+      <div
+        ref={scrollerRef}
+        data-testid="smart-screen-scroller"
+        className="custom-scrollbar h-full w-full overflow-x-auto overflow-y-auto rounded-2xl"
+        style={{ height }}
+        onScroll={handleScroll}
+      >
+        <div
+          data-testid="smart-screen-lines"
+          className="text-latte-text w-full min-w-full max-w-full px-1 py-1 font-mono text-xs sm:px-2 sm:py-2"
+        >
+          {decoratedLines.map((line, index) => (
+            <div
+              key={index}
+              data-index={index}
+              className={cn("vde-screen-line-smart min-h-4 leading-4", line.className)}
+              onClick={onLineClick}
+              onKeyDown={onLineKeyDown}
+              dangerouslySetInnerHTML={{ __html: line.lineHtml || "&#x200B;" }}
+            />
+          ))}
+        </div>
+      </div>
+      {!isAtBottom && (
+        <IconButton
+          type="button"
+          onClick={() => onScrollToBottom("smooth")}
+          aria-label="Scroll to bottom"
+          className="absolute bottom-2 right-2"
+          variant="base"
+          size="sm"
+        >
+          <ArrowDown className="h-4 w-4" />
+        </IconButton>
+      )}
+    </div>
+  );
+};

--- a/apps/web/src/pages/SessionDetail/components/SmartScreenViewport.tsx
+++ b/apps/web/src/pages/SessionDetail/components/SmartScreenViewport.tsx
@@ -149,14 +149,14 @@ export const SmartScreenViewport = ({
         <div
           data-testid="smart-screen-lines"
           className="text-latte-text w-full min-w-full max-w-full px-1 py-1 font-mono text-xs sm:px-2 sm:py-2"
+          onClick={onLineClick}
+          onKeyDown={onLineKeyDown}
         >
           {decoratedLines.map((line, index) => (
             <div
               key={index}
               data-index={index}
               className={cn("vde-screen-line-smart min-h-4 leading-4", line.className)}
-              onClick={onLineClick}
-              onKeyDown={onLineKeyDown}
               // lineHtml must come from the controlled screen pipeline
               // (server terminal output -> ansi escape -> DOM-only transforms),
               // never from unvalidated user input.

--- a/apps/web/src/pages/SessionDetail/components/SmartScreenViewport.tsx
+++ b/apps/web/src/pages/SessionDetail/components/SmartScreenViewport.tsx
@@ -131,6 +131,8 @@ export const SmartScreenViewport = ({
     [onAtBottomChange, onUserScrollStateChange],
   );
 
+  const handleScrollToBottom = useCallback(() => onScrollToBottom("smooth"), [onScrollToBottom]);
+
   return (
     <div
       className="border-latte-surface2/80 bg-latte-crust/95 shadow-inner-soft relative min-h-[260px] w-full min-w-0 max-w-full flex-1 rounded-2xl border-2 sm:min-h-[320px]"
@@ -166,7 +168,7 @@ export const SmartScreenViewport = ({
       {!isAtBottom && (
         <IconButton
           type="button"
-          onClick={() => onScrollToBottom("smooth")}
+          onClick={handleScrollToBottom}
           aria-label="Scroll to bottom"
           className="absolute bottom-2 right-2"
           variant="base"

--- a/apps/web/src/pages/SessionDetail/hooks/useScreenPanelLogReferenceLinking.test.ts
+++ b/apps/web/src/pages/SessionDetail/hooks/useScreenPanelLogReferenceLinking.test.ts
@@ -1,0 +1,149 @@
+import { act, renderHook, waitFor } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+import { useScreenPanelLogReferenceLinking } from "./useScreenPanelLogReferenceLinking";
+
+describe("useScreenPanelLogReferenceLinking", () => {
+  it("resolves candidates from full range in smart mode", async () => {
+    const onResolveFileReferenceCandidates = vi.fn(async (rawTokens: string[]) => rawTokens);
+    const { result } = renderHook(() =>
+      useScreenPanelLogReferenceLinking({
+        mode: "text",
+        effectiveWrapMode: "smart",
+        paneId: "%1",
+        sourceRepoRoot: "/repo",
+        agent: "codex",
+        screenLines: ["src/start.ts", "plain line", "tail.tsx"],
+        onResolveFileReferenceCandidates,
+        onRangeChanged: vi.fn(),
+      }),
+    );
+
+    await waitFor(() => {
+      expect(onResolveFileReferenceCandidates).toHaveBeenCalledTimes(1);
+    });
+    const firstCallTokens = onResolveFileReferenceCandidates.mock.calls[0]?.[0] ?? [];
+    expect(firstCallTokens).toEqual(expect.arrayContaining(["src/start.ts", "tail.tsx"]));
+    expect(result.current.linkifiedScreenLines.length).toBe(3);
+  });
+
+  it("uses visible-range fallback window in off mode", async () => {
+    const onResolveFileReferenceCandidates = vi.fn(async (rawTokens: string[]) => rawTokens);
+    const screenLines = Array.from({ length: 300 }, (_, index) => {
+      if (index === 0) {
+        return "src/out-of-range.ts";
+      }
+      if (index === 290) {
+        return "src/in-range.ts";
+      }
+      return `line-${index}`;
+    });
+    renderHook(() =>
+      useScreenPanelLogReferenceLinking({
+        mode: "text",
+        effectiveWrapMode: "off",
+        paneId: "%1",
+        sourceRepoRoot: "/repo",
+        agent: "codex",
+        screenLines,
+        onResolveFileReferenceCandidates,
+        onRangeChanged: vi.fn(),
+      }),
+    );
+
+    await waitFor(() => {
+      expect(onResolveFileReferenceCandidates).toHaveBeenCalledTimes(1);
+    });
+    const firstCallTokens = onResolveFileReferenceCandidates.mock.calls[0]?.[0] ?? [];
+    expect(firstCallTokens).toContain("src/in-range.ts");
+    expect(firstCallTokens).not.toContain("src/out-of-range.ts");
+  });
+
+  it("does not forward invalid range when lines are empty", () => {
+    const onRangeChanged = vi.fn();
+    const { result } = renderHook(() =>
+      useScreenPanelLogReferenceLinking({
+        mode: "text",
+        effectiveWrapMode: "off",
+        paneId: "%1",
+        sourceRepoRoot: "/repo",
+        agent: "codex",
+        screenLines: [],
+        onResolveFileReferenceCandidates: vi.fn(async () => []),
+        onRangeChanged,
+      }),
+    );
+
+    act(() => {
+      result.current.handleScreenRangeChanged({ startIndex: 0, endIndex: -1 });
+    });
+
+    expect(onRangeChanged).not.toHaveBeenCalled();
+  });
+
+  it("re-runs resolve when context key changes even if tokens are unchanged", async () => {
+    const onResolveFileReferenceCandidates = vi.fn(async (rawTokens: string[]) => rawTokens);
+    const onRangeChanged = vi.fn();
+    const { rerender } = renderHook(
+      ({ paneId }: { paneId: string }) =>
+        useScreenPanelLogReferenceLinking({
+          mode: "text",
+          effectiveWrapMode: "smart",
+          paneId,
+          sourceRepoRoot: "/repo",
+          agent: "codex",
+          screenLines: ["src/reused.ts"],
+          onResolveFileReferenceCandidates,
+          onRangeChanged,
+        }),
+      { initialProps: { paneId: "%1" } },
+    );
+
+    await waitFor(() => {
+      expect(onResolveFileReferenceCandidates).toHaveBeenCalledTimes(1);
+    });
+
+    rerender({ paneId: "%2" });
+
+    await waitFor(() => {
+      expect(onResolveFileReferenceCandidates).toHaveBeenCalledTimes(2);
+    });
+  });
+
+  it("switches from smart full-range to off fallback-window behavior", async () => {
+    const onResolveFileReferenceCandidates = vi.fn(async (rawTokens: string[]) => rawTokens);
+    const screenLines = [
+      "src/early.ts",
+      ...Array.from({ length: 170 }, () => "plain"),
+      "src/late.ts",
+      ...Array.from({ length: 9 }, () => "plain"),
+    ];
+    const { rerender } = renderHook(
+      ({ effectiveWrapMode }: { effectiveWrapMode: "off" | "smart" }) =>
+        useScreenPanelLogReferenceLinking({
+          mode: "text",
+          effectiveWrapMode,
+          paneId: "%1",
+          sourceRepoRoot: "/repo",
+          agent: "codex",
+          screenLines,
+          onResolveFileReferenceCandidates,
+          onRangeChanged: vi.fn(),
+        }),
+      { initialProps: { effectiveWrapMode: "smart" } as { effectiveWrapMode: "off" | "smart" } },
+    );
+
+    await waitFor(() => {
+      expect(onResolveFileReferenceCandidates).toHaveBeenCalledTimes(1);
+    });
+    expect(onResolveFileReferenceCandidates.mock.calls[0]?.[0]).toContain("src/early.ts");
+
+    rerender({ effectiveWrapMode: "off" });
+
+    await waitFor(() => {
+      expect(onResolveFileReferenceCandidates).toHaveBeenCalledTimes(2);
+    });
+    expect(onResolveFileReferenceCandidates.mock.calls[1]?.[0]).not.toContain("src/early.ts");
+    expect(onResolveFileReferenceCandidates.mock.calls[1]?.[0]).toContain("src/late.ts");
+  });
+});

--- a/apps/web/src/pages/SessionDetail/hooks/useScreenPanelLogReferenceLinking.ts
+++ b/apps/web/src/pages/SessionDetail/hooks/useScreenPanelLogReferenceLinking.ts
@@ -32,6 +32,7 @@ type ResolveContext = {
   agent: "codex" | "claude" | "unknown";
   effectiveWrapMode: ScreenWrapMode;
   referenceCandidateTokens: string[];
+  resolver: (rawTokens: string[]) => Promise<string[]>;
 };
 
 const areStringArraysEqual = (left: string[], right: string[]) => {
@@ -51,6 +52,7 @@ const isSameResolveContext = (left: ResolveContext, right: ResolveContext) =>
   left.sourceRepoRoot === right.sourceRepoRoot &&
   left.agent === right.agent &&
   left.effectiveWrapMode === right.effectiveWrapMode &&
+  left.resolver === right.resolver &&
   areStringArraysEqual(left.referenceCandidateTokens, right.referenceCandidateTokens);
 
 export const useScreenPanelLogReferenceLinking = ({
@@ -150,6 +152,7 @@ export const useScreenPanelLogReferenceLinking = ({
       agent,
       effectiveWrapMode,
       referenceCandidateTokens,
+      resolver: onResolveFileReferenceCandidates,
     };
     const previousResolveContext = lastResolveContextRef.current;
     if (

--- a/apps/web/src/pages/SessionDetail/hooks/useScreenPanelLogReferenceLinking.ts
+++ b/apps/web/src/pages/SessionDetail/hooks/useScreenPanelLogReferenceLinking.ts
@@ -73,6 +73,8 @@ export const useScreenPanelLogReferenceLinking = ({
     const cache = lineTokenCacheRef.current;
     const cached = cache.get(line);
     if (cached) {
+      cache.delete(line);
+      cache.set(line, cached);
       return cached;
     }
     const extracted = extractLogReferenceTokensFromLine(line);

--- a/apps/web/src/pages/SessionDetail/hooks/useScreenScroll.ts
+++ b/apps/web/src/pages/SessionDetail/hooks/useScreenScroll.ts
@@ -44,9 +44,16 @@ export const useScreenScroll = ({
 
   const scrollToBottom = useCallback(
     (behavior: "auto" | "smooth" = "auto") => {
-      if (!virtuosoRef.current || screenLinesLength === 0) return false;
-      const index = screenLinesLength - 1;
-      virtuosoRef.current.scrollToIndex({ index, align: "end", behavior });
+      if (screenLinesLength === 0) return false;
+      const hasVirtuoso = Boolean(virtuosoRef.current);
+      const hasScroller = Boolean(scrollerRef.current);
+      if (!hasVirtuoso && !hasScroller) {
+        return false;
+      }
+      if (virtuosoRef.current) {
+        const index = screenLinesLength - 1;
+        virtuosoRef.current.scrollToIndex({ index, align: "end", behavior });
+      }
       if (isAtBottom) {
         stopForceFollow();
       } else {
@@ -60,7 +67,7 @@ export const useScreenScroll = ({
       }
       window.requestAnimationFrame(() => {
         const scroller = scrollerRef.current;
-        if (scroller) {
+        if (scroller != null) {
           scroller.scrollTo({ top: scroller.scrollHeight, left: 0, behavior });
         }
       });

--- a/apps/web/src/pages/SessionDetail/hooks/useScreenScroll.ts
+++ b/apps/web/src/pages/SessionDetail/hooks/useScreenScroll.ts
@@ -6,6 +6,8 @@ import type { ScreenMode } from "@/lib/screen-loading";
 
 import { screenAtBottomAtom, screenForceFollowAtom } from "../atoms/screenAtoms";
 
+const FORCE_FOLLOW_FALLBACK_MS = 5000;
+
 type UseScreenScrollParams = {
   paneId: string;
   mode: ScreenMode;
@@ -32,7 +34,6 @@ export const useScreenScroll = ({
   const prevModeRef = useRef<ScreenMode>(mode);
   const prevPaneIdRef = useRef<string>(paneId);
   const snapToBottomRef = useRef(false);
-  const forceFollowFallbackMs = 5000;
 
   const stopForceFollow = useCallback(() => {
     setForceFollow(false);
@@ -63,7 +64,7 @@ export const useScreenScroll = ({
         }
         forceFollowTimerRef.current = window.setTimeout(() => {
           stopForceFollow();
-        }, forceFollowFallbackMs);
+        }, FORCE_FOLLOW_FALLBACK_MS);
       }
       if (!hasVirtuoso) {
         window.requestAnimationFrame(() => {
@@ -75,7 +76,7 @@ export const useScreenScroll = ({
       }
       return true;
     },
-    [forceFollowFallbackMs, isAtBottom, screenLinesLength, setForceFollow, stopForceFollow],
+    [isAtBottom, screenLinesLength, setForceFollow, stopForceFollow],
   );
 
   const handleAtBottomChange = useCallback(

--- a/apps/web/src/pages/SessionDetail/hooks/useScreenScroll.ts
+++ b/apps/web/src/pages/SessionDetail/hooks/useScreenScroll.ts
@@ -65,12 +65,14 @@ export const useScreenScroll = ({
           stopForceFollow();
         }, forceFollowFallbackMs);
       }
-      window.requestAnimationFrame(() => {
-        const scroller = scrollerRef.current;
-        if (scroller != null) {
-          scroller.scrollTo({ top: scroller.scrollHeight, left: 0, behavior });
-        }
-      });
+      if (!hasVirtuoso) {
+        window.requestAnimationFrame(() => {
+          const scroller = scrollerRef.current;
+          if (scroller != null) {
+            scroller.scrollTo({ top: scroller.scrollHeight, left: 0, behavior });
+          }
+        });
+      }
       return true;
     },
     [forceFollowFallbackMs, isAtBottom, screenLinesLength, setForceFollow, stopForceFollow],

--- a/apps/web/src/pages/SessionDetail/hooks/useScreenWrapMode.test.tsx
+++ b/apps/web/src/pages/SessionDetail/hooks/useScreenWrapMode.test.tsx
@@ -1,0 +1,43 @@
+import { act, renderHook, waitFor } from "@testing-library/react";
+import { createStore, Provider as JotaiProvider } from "jotai";
+import type { ReactNode } from "react";
+import { beforeEach, describe, expect, it } from "vitest";
+
+import { screenWrapModeAtom } from "../atoms/screenAtoms";
+import { __testables, useScreenWrapMode } from "./useScreenWrapMode";
+
+describe("useScreenWrapMode", () => {
+  const createWrapper = () => {
+    const store = createStore();
+    store.set(screenWrapModeAtom, "off");
+    return ({ children }: { children: ReactNode }) => (
+      <JotaiProvider store={store}>{children}</JotaiProvider>
+    );
+  };
+
+  beforeEach(() => {
+    window.localStorage.removeItem(__testables.SCREEN_WRAP_MODE_STORAGE_KEY);
+  });
+
+  it("uses off when no stored value exists", () => {
+    const { result } = renderHook(() => useScreenWrapMode(), { wrapper: createWrapper() });
+    expect(result.current.wrapMode).toBe("off");
+  });
+
+  it("restores stored wrap mode from localStorage", async () => {
+    window.localStorage.setItem(__testables.SCREEN_WRAP_MODE_STORAGE_KEY, "smart");
+    const { result } = renderHook(() => useScreenWrapMode(), { wrapper: createWrapper() });
+    await waitFor(() => {
+      expect(result.current.wrapMode).toBe("smart");
+    });
+  });
+
+  it("persists toggled value to localStorage", () => {
+    const { result } = renderHook(() => useScreenWrapMode(), { wrapper: createWrapper() });
+    act(() => {
+      result.current.toggleWrapMode();
+    });
+    expect(result.current.wrapMode).toBe("smart");
+    expect(window.localStorage.getItem(__testables.SCREEN_WRAP_MODE_STORAGE_KEY)).toBe("smart");
+  });
+});

--- a/apps/web/src/pages/SessionDetail/hooks/useScreenWrapMode.ts
+++ b/apps/web/src/pages/SessionDetail/hooks/useScreenWrapMode.ts
@@ -1,0 +1,64 @@
+import { useAtom } from "jotai";
+import { useCallback, useEffect, useRef } from "react";
+
+import { type ScreenWrapMode, screenWrapModeAtom } from "../atoms/screenAtoms";
+
+const SCREEN_WRAP_MODE_STORAGE_KEY = "vde-monitor-session-detail-screen-wrap-mode";
+
+const isScreenWrapMode = (value: string | null): value is ScreenWrapMode =>
+  value === "off" || value === "smart";
+
+const readStoredWrapMode = (): ScreenWrapMode | null => {
+  try {
+    const stored = window.localStorage.getItem(SCREEN_WRAP_MODE_STORAGE_KEY);
+    return isScreenWrapMode(stored) ? stored : null;
+  } catch {
+    return null;
+  }
+};
+
+const writeStoredWrapMode = (wrapMode: ScreenWrapMode) => {
+  try {
+    window.localStorage.setItem(SCREEN_WRAP_MODE_STORAGE_KEY, wrapMode);
+  } catch {
+    // ignore storage errors
+  }
+};
+
+export const useScreenWrapMode = () => {
+  const [wrapMode, setWrapModeAtom] = useAtom(screenWrapModeAtom);
+  const loadedRef = useRef(false);
+
+  useEffect(() => {
+    if (loadedRef.current) {
+      return;
+    }
+    loadedRef.current = true;
+    const stored = readStoredWrapMode();
+    if (stored && stored !== wrapMode) {
+      setWrapModeAtom(stored);
+    }
+  }, [setWrapModeAtom, wrapMode]);
+
+  const setWrapMode = useCallback(
+    (nextWrapMode: ScreenWrapMode) => {
+      setWrapModeAtom(nextWrapMode);
+      writeStoredWrapMode(nextWrapMode);
+    },
+    [setWrapModeAtom],
+  );
+
+  const toggleWrapMode = useCallback(() => {
+    setWrapMode(wrapMode === "smart" ? "off" : "smart");
+  }, [setWrapMode, wrapMode]);
+
+  return {
+    wrapMode,
+    setWrapMode,
+    toggleWrapMode,
+  };
+};
+
+export const __testables = {
+  SCREEN_WRAP_MODE_STORAGE_KEY,
+};

--- a/apps/web/src/pages/SessionDetail/hooks/useSessionDetailViewExplorerSectionProps.ts
+++ b/apps/web/src/pages/SessionDetail/hooks/useSessionDetailViewExplorerSectionProps.ts
@@ -15,6 +15,7 @@ export const useSessionDetailViewExplorerSectionProps = ({
   const { resolvedTheme } = sidebar;
   const {
     mode,
+    wrapMode,
     screenLines,
     imageBase64,
     fallbackReason,
@@ -28,6 +29,7 @@ export const useSessionDetailViewExplorerSectionProps = ({
     forceFollow,
     scrollToBottom,
     handleModeChange,
+    toggleWrapMode,
     virtuosoRef,
     scrollerRef,
     handleRefreshScreen,
@@ -46,6 +48,10 @@ export const useSessionDetailViewExplorerSectionProps = ({
     clearVirtualWorktree,
   } = screen;
   const sourceRepoRoot = effectiveWorktreePath ?? session?.repoRoot ?? null;
+  const screenAgent: "codex" | "claude" | "unknown" =
+    session?.agent === "codex" || session?.agent === "claude" || session?.agent === "unknown"
+      ? session.agent
+      : "unknown";
   const { diffSummary, diffError, diffFiles, diffLoadingFiles, ensureDiffFile } = diffs;
   const { rawMode, allowDangerKeys } = controls;
   const {
@@ -275,6 +281,10 @@ export const useSessionDetailViewExplorerSectionProps = ({
     () => ({
       state: {
         mode,
+        wrapMode,
+        paneId,
+        sourceRepoRoot,
+        agent: screenAgent,
         connectionIssue,
         fallbackReason,
         error,
@@ -302,6 +312,7 @@ export const useSessionDetailViewExplorerSectionProps = ({
       },
       actions: {
         onModeChange: handleModeChange,
+        onToggleWrapMode: toggleWrapMode,
         onRefresh: handleRefreshScreen,
         onRefreshWorktrees: () => {
           void (handleRefreshWorktrees ?? handleRefreshScreen)();
@@ -317,6 +328,10 @@ export const useSessionDetailViewExplorerSectionProps = ({
     }),
     [
       mode,
+      wrapMode,
+      paneId,
+      sourceRepoRoot,
+      screenAgent,
       connectionIssue,
       fallbackReason,
       error,
@@ -349,6 +364,7 @@ export const useSessionDetailViewExplorerSectionProps = ({
       handleUserScrollStateChange,
       selectVirtualWorktree,
       clearVirtualWorktree,
+      toggleWrapMode,
       handleResolveFileReference,
       handleResolveFileReferenceCandidates,
     ],

--- a/apps/web/src/pages/SessionDetail/hooks/useSessionDetailViewExplorerSectionProps.ts
+++ b/apps/web/src/pages/SessionDetail/hooks/useSessionDetailViewExplorerSectionProps.ts
@@ -48,10 +48,7 @@ export const useSessionDetailViewExplorerSectionProps = ({
     clearVirtualWorktree,
   } = screen;
   const sourceRepoRoot = effectiveWorktreePath ?? session?.repoRoot ?? null;
-  const screenAgent: "codex" | "claude" | "unknown" =
-    session?.agent === "codex" || session?.agent === "claude" || session?.agent === "unknown"
-      ? session.agent
-      : "unknown";
+  const screenAgent = session?.agent ?? "unknown";
   const { diffSummary, diffError, diffFiles, diffLoadingFiles, ensureDiffFile } = diffs;
   const { rawMode, allowDangerKeys } = controls;
   const {

--- a/apps/web/src/pages/SessionDetail/hooks/useSessionScreen.ts
+++ b/apps/web/src/pages/SessionDetail/hooks/useSessionScreen.ts
@@ -21,6 +21,7 @@ import { DISCONNECTED_MESSAGE } from "../sessionDetailUtils";
 import { useScreenFetch } from "./useScreenFetch";
 import { useScreenMode } from "./useScreenMode";
 import { useScreenScroll } from "./useScreenScroll";
+import { useScreenWrapMode } from "./useScreenWrapMode";
 
 type UseSessionScreenParams = {
   paneId: string;
@@ -45,6 +46,7 @@ export const useSessionScreen = ({
   const setScreenError = useSetAtom(screenErrorAtom);
   const screenLines = useAtomValue(screenLinesAtom);
   const mode = useAtomValue(screenModeAtom);
+  const { wrapMode, toggleWrapMode } = useScreenWrapMode();
 
   const isUserScrollingRef = useRef(false);
   const pendingScreenRef = useRef<string | null>(null);
@@ -157,6 +159,7 @@ export const useSessionScreen = ({
 
   return {
     mode,
+    wrapMode,
     screenLines,
     imageBase64,
     fallbackReason,
@@ -171,6 +174,7 @@ export const useSessionScreen = ({
     refreshScreen,
     scrollToBottom,
     handleModeChange,
+    toggleWrapMode,
     virtuosoRef,
     scrollerRef,
   };

--- a/apps/web/src/pages/SessionDetail/smart-wrap-classify.test.ts
+++ b/apps/web/src/pages/SessionDetail/smart-wrap-classify.test.ts
@@ -1,0 +1,169 @@
+import { describe, expect, it } from "vitest";
+
+import { classifySmartWrapLines } from "./smart-wrap-classify";
+
+describe("classifySmartWrapLines", () => {
+  it("classifies codex diff-like block lines as no-wrap block", () => {
+    const lines = [
+      "• Edited tmp/file.md (+12 -2)",
+      "    358  before",
+      "    359 - before",
+      "    360 + after",
+      "    ⋮",
+      "plain line",
+    ];
+    const result = classifySmartWrapLines(lines, "codex");
+    expect(result.map((item) => item.rule)).toEqual([
+      "codex-diff-block",
+      "codex-diff-block",
+      "codex-diff-block",
+      "codex-diff-block",
+      "codex-diff-block",
+      "statusline-preserve",
+    ]);
+  });
+
+  it("keeps wrapped fragments between codex diff rows in no-wrap block", () => {
+    const lines = [
+      "• Edited apps/web/src/pages/SessionDetail/components/ScreenPanel.test.tsx (+12 -2)",
+      '  112 - it("uses virtuoso rendering path when',
+      'smart wrap is enabled", () => {',
+      '  112 + it("uses non-virtualized rendering path when',
+      'smart wrap is enabled", () => {',
+      "  113    const state = buildState({",
+      "43% left",
+    ];
+    const result = classifySmartWrapLines(lines, "codex");
+    expect(result.map((item) => item.rule)).toEqual([
+      "codex-diff-block",
+      "codex-diff-block",
+      "codex-diff-block",
+      "codex-diff-block",
+      "codex-diff-block",
+      "codex-diff-block",
+      "statusline-preserve",
+    ]);
+  });
+
+  it("keeps wrapped fragments when codex continuation rows have no leading indent", () => {
+    const lines = [
+      "• Edited apps/web/src/pages/SessionDetail/smart-wrap-classify.ts (+14 -1)",
+      "68 +const stripInvisibleChars = (value: string)",
+      '=> value.replace(/[\\u200B\\uFEFF]/g, "");',
+      "69 +",
+      "70 +const isBlankLikeLine = (value: string) =>",
+      "stripInvisibleChars(value).trim().length === 0;",
+      "71 +",
+      "72    const detectBlockLineSet = (",
+      "43% left",
+    ];
+    const result = classifySmartWrapLines(lines, "codex");
+    expect(result.map((item) => item.rule)).toEqual([
+      "codex-diff-block",
+      "codex-diff-block",
+      "codex-diff-block",
+      "codex-diff-block",
+      "codex-diff-block",
+      "codex-diff-block",
+      "codex-diff-block",
+      "codex-diff-block",
+      "statusline-preserve",
+    ]);
+  });
+
+  it("accepts codex diff start line without (+x -y) suffix", () => {
+    const lines = [
+      "• Edited apps/web/src/pages/SessionDetail/components/ScreenPanel.tsx",
+      "  10 + const value = 1;",
+      "43% left",
+    ];
+    const result = classifySmartWrapLines(lines, "codex");
+    expect(result.map((item) => item.rule)).toEqual([
+      "codex-diff-block",
+      "codex-diff-block",
+      "statusline-preserve",
+    ]);
+  });
+
+  it("does not bleed codex diff block across blank-like and divider lines", () => {
+    const lines = [
+      "• Edited apps/web/src/example.ts (+1 -1)",
+      "  10 - before",
+      "  10 + after",
+      "\u200B",
+      "────────────────────────────────",
+      "• normal commentary",
+      "  20 + looks-like-continuation-without-start",
+      "43% left",
+    ];
+    const result = classifySmartWrapLines(lines, "codex");
+    expect(result[0]?.rule).toBe("codex-diff-block");
+    expect(result[1]?.rule).toBe("codex-diff-block");
+    expect(result[2]?.rule).toBe("codex-diff-block");
+    expect(result[3]?.rule).toBe("default");
+    expect(result[4]?.rule).toBe("divider-clip");
+    expect(result[5]?.rule).not.toBe("codex-diff-block");
+    expect(result[6]?.rule).not.toBe("codex-diff-block");
+    expect(result[7]?.rule).toBe("statusline-preserve");
+  });
+
+  it("classifies claude tool block lines with strict continuation rules", () => {
+    const lines = ["⏺ Bash(ls -la)", "  ⎿ Done", "      1 line", "      ", "next line"];
+    const result = classifySmartWrapLines(lines, "claude");
+    expect(result.map((item) => item.rule)).toEqual([
+      "claude-tool-block",
+      "claude-tool-block",
+      "claude-tool-block",
+      "claude-tool-block",
+      "statusline-preserve",
+    ]);
+  });
+
+  it("detects list long-word without filepath-specific dependency", () => {
+    const lines = ["- supercalifragilisticexpialidocious token", "43% left"];
+    const result = classifySmartWrapLines(lines, "codex");
+    expect(result[0]).toEqual({
+      rule: "list-long-word",
+      indentCh: 2,
+      listPrefix: "- ",
+    });
+  });
+
+  it("keeps table preserve priority over label-indent", () => {
+    const lines = ['<span class="vde-unicode-table-wrap">Search header</span>', "43% left"];
+    const result = classifySmartWrapLines(lines, "codex");
+    expect(result[0]?.rule).toBe("table-preserve");
+  });
+
+  it("switches divider classifier by agent", () => {
+    const divider = "────────────────────────────────";
+    expect(classifySmartWrapLines([divider, "❯ "], "claude")[0]?.rule).toBe("divider-clip");
+    expect(classifySmartWrapLines([divider], "unknown")[0]?.rule).toBe("default");
+  });
+
+  it("treats codex worked-for separator as divider-clip", () => {
+    const lines = ["─ Worked for 1m 17s ──────────────────────────────", "43% left"];
+    const result = classifySmartWrapLines(lines, "codex");
+    expect(result[0]?.rule).toBe("divider-clip");
+  });
+
+  it("marks the last line as statusline-preserve for codex", () => {
+    const lines = ["Search long-token-example", "43% left"];
+    const result = classifySmartWrapLines(lines, "codex");
+    expect(result[0]?.rule).toBe("label-indent");
+    expect(result[1]?.rule).toBe("statusline-preserve");
+  });
+
+  it("marks the last line as statusline-preserve for claude", () => {
+    const lines = ["⏺ Read 1 file", "❯ "];
+    const result = classifySmartWrapLines(lines, "claude");
+    expect(result[0]?.rule).toBe("claude-tool-block");
+    expect(result[1]?.rule).toBe("statusline-preserve");
+  });
+
+  it("does not mark last line for unknown agent", () => {
+    const lines = ["line 1", "line 2"];
+    const result = classifySmartWrapLines(lines, "unknown");
+    expect(result[1]?.rule).toBe("default");
+  });
+});

--- a/apps/web/src/pages/SessionDetail/smart-wrap-classify.ts
+++ b/apps/web/src/pages/SessionDetail/smart-wrap-classify.ts
@@ -1,253 +1,29 @@
-export type SmartWrapAgent = "codex" | "claude" | "unknown";
+import {
+  detectClaudeToolBlockLineSet,
+  detectCodexDiffBlockLineSet,
+  isTableLine,
+  resolveDivider,
+  resolveGenericIndent,
+  resolveLabelIndent,
+  resolveListLongWord,
+} from "./smart-wrap-rules";
+import { extractTextContentFromHtml } from "./smart-wrap-text";
+import type { SmartWrapAgent, SmartWrapLineClassification } from "./smart-wrap-types";
 
-export type SmartWrapLineRule =
-  | "default"
-  | "statusline-preserve"
-  | "claude-tool-block"
-  | "codex-diff-block"
-  | "table-preserve"
-  | "divider-clip"
-  | "label-indent"
-  | "list-long-word"
-  | "generic-indent";
+export type {
+  SmartWrapAgent,
+  SmartWrapLineClassification,
+  SmartWrapLineRule,
+} from "./smart-wrap-types";
 
-export type SmartWrapLineClassification = {
-  rule: SmartWrapLineRule;
-  indentCh: number | null;
-  listPrefix: string | null;
-};
-
-const LIST_LONG_WORD_THRESHOLD_CH = 12;
-const MIN_INDENT_CH = 2;
-const MAX_INDENT_CH = 24;
-const sharedParser = typeof DOMParser === "undefined" ? null : new DOMParser();
-const stripInvisibleChars = (value: string) => value.replace(/[\u200B\uFEFF]/g, "");
-
-const CODEX_DIFF_START_PATTERNS = [
-  /^\s*•\s+(Edited|Added|Deleted|Renamed)\s+.+\(\+\d+\s+-\d+\)\s*$/,
-  /^\s*•\s+(Edited|Added|Deleted|Renamed)\s+.+\(\+\d+\)\s*$/,
-  /^\s*•\s+(Edited|Added|Deleted|Renamed)\s+\S*(?:\/|\\|\.)\S*(?:\s+\(\+\d+(?:\s+-\d+)?\))?\s*$/,
-];
-const CODEX_DIFF_CONTINUATION_PATTERNS = [
-  /^\s*\d+\s{2,}.*$/,
-  /^\s*\d+\s+[+-]\s?.*$/,
-  /^\s+[+-]\s.*$/,
-  /^\s+(?:⋮|:)\s*$/,
-];
-const CODEX_LABELED_DIVIDER_PATTERN = /^\s*[─━-]\s+Worked for\b.+[─━-]{8,}\s*$/;
-const MAX_CODEX_WRAPPED_FRAGMENT_LINES = 3;
-const CLAUDE_TOOL_START_PATTERN = /^\s*⏺\s+(Read|Bash|Write|Update|Edit|MultiEdit)\b.*$/;
-const CLAUDE_TOOL_CONTINUATION_PATTERNS = [/^\s{2,}⎿\s+.*$/, /^\s{6,}\d+\s+.*$/, /^\s{6,}$/];
-const CODEX_LABEL_PATTERN = /^\s*(?:[│└├]\s*)?(Search|Read)\s+/;
-const CLAUDE_LABEL_PATTERN = /^\s*⏺\s+(Read|Bash|Write|Update|Edit|MultiEdit)\b/;
-const LIST_LONG_WORD_PATTERN = /^(\s*(?:[-*+]\s+|\d+[.)]\s+))(\S+)/;
-const GENERIC_INDENT_PATTERNS = [
-  /^\s*(?:[-*+•]\s+|\d+[.)]\s+|[A-Za-z]\)\s+)/,
-  /^\s*>\s+/,
-  /^\s*(?:\[\d{1,2}:\d{2}:\d{2}\]\s+)?(?:TRACE|DEBUG|INFO|WARN|ERROR|FATAL)\s+/,
-];
-
-const extractTextContentFromHtml = (lineHtml: string) => {
-  if (!lineHtml) {
-    return "";
-  }
-  if (!sharedParser) {
-    return stripInvisibleChars(lineHtml.replace(/<[^>]*>/g, ""));
-  }
-  const document = sharedParser.parseFromString(`<div>${lineHtml}</div>`, "text/html");
-  return stripInvisibleChars(document.body.firstElementChild?.textContent ?? "");
-};
-
-const countCh = (value: string) => [...value].length;
-
-const matchesAny = (value: string, patterns: RegExp[]) =>
-  patterns.some((pattern) => pattern.test(value));
-
-const isBlankLikeLine = (value: string) => stripInvisibleChars(value).trim().length === 0;
-
-const detectBlockLineSet = (
-  textLines: string[],
-  isStart: (line: string) => boolean,
-  isContinuation: (line: string) => boolean,
-) => {
-  const result = new Set<number>();
-  let index = 0;
-  while (index < textLines.length) {
-    const current = textLines[index] ?? "";
-    if (!isStart(current)) {
-      index += 1;
-      continue;
-    }
-    result.add(index);
-    let nextIndex = index + 1;
-    while (nextIndex < textLines.length) {
-      const next = textLines[nextIndex] ?? "";
-      if (!isContinuation(next)) {
-        break;
-      }
-      result.add(nextIndex);
-      nextIndex += 1;
-    }
-    index = nextIndex;
-  }
-  return result;
-};
-
-const detectCodexDiffBlockLineSet = (textLines: string[]) => {
-  const result = new Set<number>();
-  let index = 0;
-  while (index < textLines.length) {
-    const current = textLines[index] ?? "";
-    if (!matchesAny(current, CODEX_DIFF_START_PATTERNS)) {
-      index += 1;
-      continue;
-    }
-    result.add(index);
-    let nextIndex = index + 1;
-    while (nextIndex < textLines.length) {
-      const next = textLines[nextIndex] ?? "";
-      if (matchesAny(next, CODEX_DIFF_CONTINUATION_PATTERNS)) {
-        result.add(nextIndex);
-        nextIndex += 1;
-        continue;
-      }
-
-      const wrappedStart = nextIndex;
-      const wrappedMaxExclusive = Math.min(
-        textLines.length,
-        wrappedStart + MAX_CODEX_WRAPPED_FRAGMENT_LINES,
-      );
-      while (nextIndex < textLines.length) {
-        const candidate = textLines[nextIndex] ?? "";
-        if (isBlankLikeLine(candidate)) {
-          break;
-        }
-        if (isCodexDivider(candidate)) {
-          break;
-        }
-        if (matchesAny(candidate, CODEX_DIFF_START_PATTERNS)) {
-          break;
-        }
-        if (matchesAny(candidate, CODEX_DIFF_CONTINUATION_PATTERNS)) {
-          break;
-        }
-        nextIndex += 1;
-        if (nextIndex >= wrappedMaxExclusive) {
-          break;
-        }
-      }
-
-      if (
-        nextIndex > wrappedStart &&
-        nextIndex < textLines.length &&
-        matchesAny(textLines[nextIndex] ?? "", CODEX_DIFF_CONTINUATION_PATTERNS)
-      ) {
-        for (let cursor = wrappedStart; cursor < nextIndex; cursor += 1) {
-          result.add(cursor);
-        }
-        continue;
-      }
-
-      nextIndex = wrappedStart;
-      break;
-    }
-    index = nextIndex;
-  }
-  return result;
-};
-
-const isTableLine = (lineHtml: string) =>
-  lineHtml.includes("vde-unicode-table-wrap") || lineHtml.includes("vde-markdown-pipe-table-wrap");
-
-const isCodexDivider = (text: string) => {
-  const trimmed = text.trim();
-  if (trimmed.length < 6) {
-    return false;
-  }
-  if (CODEX_LABELED_DIVIDER_PATTERN.test(trimmed)) {
-    return true;
-  }
-  if (/[A-Za-z0-9]/.test(trimmed)) {
-    return false;
-  }
-  return /^[-=_*─━]+$/.test(trimmed);
-};
-
-const isClaudeDivider = (text: string) => {
-  const trimmed = text.trim();
-  return /^─{20,}$/.test(trimmed) || /^[╭╰]─{10,}[╮╯]$/.test(trimmed);
-};
-
-const resolveCodexLabelIndent = (text: string): number | null => {
-  const match = text.match(CODEX_LABEL_PATTERN);
-  if (!match) {
-    return null;
-  }
-  return countCh(match[0]);
-};
-
-const resolveClaudeLabelIndent = (text: string): number | null => {
-  const match = text.match(CLAUDE_LABEL_PATTERN);
-  if (!match) {
-    return null;
-  }
-  let anchor = match[0].length;
-  const nextChar = text[anchor];
-  if (nextChar === "(") {
-    anchor += 1;
-  } else if (nextChar === " ") {
-    anchor += 1;
-  }
-  return countCh(text.slice(0, anchor));
-};
-
-const resolveGenericIndent = (text: string): number | null => {
-  for (const pattern of GENERIC_INDENT_PATTERNS) {
-    const match = text.match(pattern);
-    if (!match) {
-      continue;
-    }
-    const indentCh = countCh(match[0]);
-    if (indentCh < MIN_INDENT_CH || indentCh > MAX_INDENT_CH) {
-      return null;
-    }
-    return indentCh;
-  }
-  return null;
-};
-
-const resolveListLongWord = (
-  agent: SmartWrapAgent,
-  text: string,
-): { indentCh: number; listPrefix: string } | null => {
-  if (agent !== "codex") {
-    return null;
-  }
-  const match = text.match(LIST_LONG_WORD_PATTERN);
-  if (!match) {
-    return null;
-  }
-  const listPrefix = match[1] ?? "";
-  const firstToken = match[2] ?? "";
-  if (countCh(firstToken) < LIST_LONG_WORD_THRESHOLD_CH) {
-    return null;
-  }
-  const indentCh = countCh(listPrefix);
-  if (indentCh < MIN_INDENT_CH || indentCh > MAX_INDENT_CH) {
-    return null;
-  }
-  return { indentCh, listPrefix };
-};
-
-const resolveDivider = (agent: SmartWrapAgent, text: string) => {
-  if (agent === "codex") {
-    return isCodexDivider(text);
-  }
-  if (agent === "claude") {
-    return isClaudeDivider(text);
-  }
-  return false;
-};
+const buildClassification = (
+  rule: SmartWrapLineClassification["rule"],
+  options?: { indentCh?: number | null; listPrefix?: string | null },
+): SmartWrapLineClassification => ({
+  rule,
+  indentCh: options?.indentCh ?? null,
+  listPrefix: options?.listPrefix ?? null,
+});
 
 export const classifySmartWrapLines = (
   lineHtmlList: string[],
@@ -257,89 +33,41 @@ export const classifySmartWrapLines = (
   const codexDiffBlockLineSet =
     agent === "codex" ? detectCodexDiffBlockLineSet(textLines) : new Set<number>();
   const claudeToolBlockLineSet =
-    agent === "claude"
-      ? detectBlockLineSet(
-          textLines,
-          (line) => CLAUDE_TOOL_START_PATTERN.test(line),
-          (line) => matchesAny(line, CLAUDE_TOOL_CONTINUATION_PATTERNS),
-        )
-      : new Set<number>();
+    agent === "claude" ? detectClaudeToolBlockLineSet(textLines) : new Set<number>();
 
   return lineHtmlList.map((lineHtml, index) => {
     const text = textLines[index] ?? "";
     const isLastLine = index === lineHtmlList.length - 1;
     if (isLastLine && (agent === "codex" || agent === "claude")) {
-      return {
-        rule: "statusline-preserve",
-        indentCh: null,
-        listPrefix: null,
-      };
+      return buildClassification("statusline-preserve");
     }
     if (claudeToolBlockLineSet.has(index)) {
-      return {
-        rule: "claude-tool-block",
-        indentCh: null,
-        listPrefix: null,
-      };
+      return buildClassification("claude-tool-block");
     }
     if (codexDiffBlockLineSet.has(index)) {
-      return {
-        rule: "codex-diff-block",
-        indentCh: null,
-        listPrefix: null,
-      };
+      return buildClassification("codex-diff-block");
     }
     if (isTableLine(lineHtml)) {
-      return {
-        rule: "table-preserve",
-        indentCh: null,
-        listPrefix: null,
-      };
+      return buildClassification("table-preserve");
     }
     if (resolveDivider(agent, text)) {
-      return {
-        rule: "divider-clip",
-        indentCh: null,
-        listPrefix: null,
-      };
+      return buildClassification("divider-clip");
     }
-    const labelIndent =
-      agent === "codex"
-        ? resolveCodexLabelIndent(text)
-        : agent === "claude"
-          ? resolveClaudeLabelIndent(text)
-          : null;
+    const labelIndent = resolveLabelIndent(agent, text);
     if (labelIndent != null) {
-      return {
-        rule: "label-indent",
-        indentCh: labelIndent,
-        listPrefix: null,
-      };
+      return buildClassification("label-indent", { indentCh: labelIndent });
     }
     const listLongWord = resolveListLongWord(agent, text);
     if (listLongWord) {
-      return {
-        rule: "list-long-word",
+      return buildClassification("list-long-word", {
         indentCh: listLongWord.indentCh,
         listPrefix: listLongWord.listPrefix,
-      };
+      });
     }
     const genericIndent = resolveGenericIndent(text);
     if (genericIndent != null) {
-      return {
-        rule: "generic-indent",
-        indentCh: genericIndent,
-        listPrefix: null,
-      };
+      return buildClassification("generic-indent", { indentCh: genericIndent });
     }
-    return {
-      rule: "default",
-      indentCh: null,
-      listPrefix: null,
-    };
+    return buildClassification("default");
   });
-};
-
-export const __testables = {
-  extractTextContentFromHtml,
 };

--- a/apps/web/src/pages/SessionDetail/smart-wrap-classify.ts
+++ b/apps/web/src/pages/SessionDetail/smart-wrap-classify.ts
@@ -1,0 +1,345 @@
+export type SmartWrapAgent = "codex" | "claude" | "unknown";
+
+export type SmartWrapLineRule =
+  | "default"
+  | "statusline-preserve"
+  | "claude-tool-block"
+  | "codex-diff-block"
+  | "table-preserve"
+  | "divider-clip"
+  | "label-indent"
+  | "list-long-word"
+  | "generic-indent";
+
+export type SmartWrapLineClassification = {
+  rule: SmartWrapLineRule;
+  indentCh: number | null;
+  listPrefix: string | null;
+};
+
+const LIST_LONG_WORD_THRESHOLD_CH = 12;
+const MIN_INDENT_CH = 2;
+const MAX_INDENT_CH = 24;
+const sharedParser = typeof DOMParser === "undefined" ? null : new DOMParser();
+const stripInvisibleChars = (value: string) => value.replace(/[\u200B\uFEFF]/g, "");
+
+const CODEX_DIFF_START_PATTERNS = [
+  /^\s*•\s+(Edited|Added|Deleted|Renamed)\s+.+\(\+\d+\s+-\d+\)\s*$/,
+  /^\s*•\s+(Edited|Added|Deleted|Renamed)\s+.+\(\+\d+\)\s*$/,
+  /^\s*•\s+(Edited|Added|Deleted|Renamed)\s+\S*(?:\/|\\|\.)\S*(?:\s+\(\+\d+(?:\s+-\d+)?\))?\s*$/,
+];
+const CODEX_DIFF_CONTINUATION_PATTERNS = [
+  /^\s*\d+\s{2,}.*$/,
+  /^\s*\d+\s+[+-]\s?.*$/,
+  /^\s+[+-]\s.*$/,
+  /^\s+(?:⋮|:)\s*$/,
+];
+const CODEX_LABELED_DIVIDER_PATTERN = /^\s*[─━-]\s+Worked for\b.+[─━-]{8,}\s*$/;
+const MAX_CODEX_WRAPPED_FRAGMENT_LINES = 3;
+const CLAUDE_TOOL_START_PATTERN = /^\s*⏺\s+(Read|Bash|Write|Update|Edit|MultiEdit)\b.*$/;
+const CLAUDE_TOOL_CONTINUATION_PATTERNS = [/^\s{2,}⎿\s+.*$/, /^\s{6,}\d+\s+.*$/, /^\s{6,}$/];
+const CODEX_LABEL_PATTERN = /^\s*(?:[│└├]\s*)?(Search|Read)\s+/;
+const CLAUDE_LABEL_PATTERN = /^\s*⏺\s+(Read|Bash|Write|Update|Edit|MultiEdit)\b/;
+const LIST_LONG_WORD_PATTERN = /^(\s*(?:[-*+]\s+|\d+[.)]\s+))(\S+)/;
+const GENERIC_INDENT_PATTERNS = [
+  /^\s*(?:[-*+•]\s+|\d+[.)]\s+|[A-Za-z]\)\s+)/,
+  /^\s*>\s+/,
+  /^\s*(?:\[\d{1,2}:\d{2}:\d{2}\]\s+)?(?:TRACE|DEBUG|INFO|WARN|ERROR|FATAL)\s+/,
+];
+
+const extractTextContentFromHtml = (lineHtml: string) => {
+  if (!lineHtml) {
+    return "";
+  }
+  if (!sharedParser) {
+    return stripInvisibleChars(lineHtml.replace(/<[^>]*>/g, ""));
+  }
+  const document = sharedParser.parseFromString(`<div>${lineHtml}</div>`, "text/html");
+  return stripInvisibleChars(document.body.firstElementChild?.textContent ?? "");
+};
+
+const countCh = (value: string) => [...value].length;
+
+const matchesAny = (value: string, patterns: RegExp[]) =>
+  patterns.some((pattern) => pattern.test(value));
+
+const isBlankLikeLine = (value: string) => stripInvisibleChars(value).trim().length === 0;
+
+const detectBlockLineSet = (
+  textLines: string[],
+  isStart: (line: string) => boolean,
+  isContinuation: (line: string) => boolean,
+) => {
+  const result = new Set<number>();
+  let index = 0;
+  while (index < textLines.length) {
+    const current = textLines[index] ?? "";
+    if (!isStart(current)) {
+      index += 1;
+      continue;
+    }
+    result.add(index);
+    let nextIndex = index + 1;
+    while (nextIndex < textLines.length) {
+      const next = textLines[nextIndex] ?? "";
+      if (!isContinuation(next)) {
+        break;
+      }
+      result.add(nextIndex);
+      nextIndex += 1;
+    }
+    index = nextIndex;
+  }
+  return result;
+};
+
+const detectCodexDiffBlockLineSet = (textLines: string[]) => {
+  const result = new Set<number>();
+  let index = 0;
+  while (index < textLines.length) {
+    const current = textLines[index] ?? "";
+    if (!matchesAny(current, CODEX_DIFF_START_PATTERNS)) {
+      index += 1;
+      continue;
+    }
+    result.add(index);
+    let nextIndex = index + 1;
+    while (nextIndex < textLines.length) {
+      const next = textLines[nextIndex] ?? "";
+      if (matchesAny(next, CODEX_DIFF_CONTINUATION_PATTERNS)) {
+        result.add(nextIndex);
+        nextIndex += 1;
+        continue;
+      }
+
+      const wrappedStart = nextIndex;
+      const wrappedMaxExclusive = Math.min(
+        textLines.length,
+        wrappedStart + MAX_CODEX_WRAPPED_FRAGMENT_LINES,
+      );
+      while (nextIndex < textLines.length) {
+        const candidate = textLines[nextIndex] ?? "";
+        if (isBlankLikeLine(candidate)) {
+          break;
+        }
+        if (isCodexDivider(candidate)) {
+          break;
+        }
+        if (matchesAny(candidate, CODEX_DIFF_START_PATTERNS)) {
+          break;
+        }
+        if (matchesAny(candidate, CODEX_DIFF_CONTINUATION_PATTERNS)) {
+          break;
+        }
+        nextIndex += 1;
+        if (nextIndex >= wrappedMaxExclusive) {
+          break;
+        }
+      }
+
+      if (
+        nextIndex > wrappedStart &&
+        nextIndex < textLines.length &&
+        matchesAny(textLines[nextIndex] ?? "", CODEX_DIFF_CONTINUATION_PATTERNS)
+      ) {
+        for (let cursor = wrappedStart; cursor < nextIndex; cursor += 1) {
+          result.add(cursor);
+        }
+        continue;
+      }
+
+      nextIndex = wrappedStart;
+      break;
+    }
+    index = nextIndex;
+  }
+  return result;
+};
+
+const isTableLine = (lineHtml: string) =>
+  lineHtml.includes("vde-unicode-table-wrap") || lineHtml.includes("vde-markdown-pipe-table-wrap");
+
+const isCodexDivider = (text: string) => {
+  const trimmed = text.trim();
+  if (trimmed.length < 6) {
+    return false;
+  }
+  if (CODEX_LABELED_DIVIDER_PATTERN.test(trimmed)) {
+    return true;
+  }
+  if (/[A-Za-z0-9]/.test(trimmed)) {
+    return false;
+  }
+  return /^[-=_*─━]+$/.test(trimmed);
+};
+
+const isClaudeDivider = (text: string) => {
+  const trimmed = text.trim();
+  return /^─{20,}$/.test(trimmed) || /^[╭╰]─{10,}[╮╯]$/.test(trimmed);
+};
+
+const resolveCodexLabelIndent = (text: string): number | null => {
+  const match = text.match(CODEX_LABEL_PATTERN);
+  if (!match) {
+    return null;
+  }
+  return countCh(match[0]);
+};
+
+const resolveClaudeLabelIndent = (text: string): number | null => {
+  const match = text.match(CLAUDE_LABEL_PATTERN);
+  if (!match) {
+    return null;
+  }
+  let anchor = match[0].length;
+  const nextChar = text[anchor];
+  if (nextChar === "(") {
+    anchor += 1;
+  } else if (nextChar === " ") {
+    anchor += 1;
+  }
+  return countCh(text.slice(0, anchor));
+};
+
+const resolveGenericIndent = (text: string): number | null => {
+  for (const pattern of GENERIC_INDENT_PATTERNS) {
+    const match = text.match(pattern);
+    if (!match) {
+      continue;
+    }
+    const indentCh = countCh(match[0]);
+    if (indentCh < MIN_INDENT_CH || indentCh > MAX_INDENT_CH) {
+      return null;
+    }
+    return indentCh;
+  }
+  return null;
+};
+
+const resolveListLongWord = (
+  agent: SmartWrapAgent,
+  text: string,
+): { indentCh: number; listPrefix: string } | null => {
+  if (agent !== "codex") {
+    return null;
+  }
+  const match = text.match(LIST_LONG_WORD_PATTERN);
+  if (!match) {
+    return null;
+  }
+  const listPrefix = match[1] ?? "";
+  const firstToken = match[2] ?? "";
+  if (countCh(firstToken) < LIST_LONG_WORD_THRESHOLD_CH) {
+    return null;
+  }
+  const indentCh = countCh(listPrefix);
+  if (indentCh < MIN_INDENT_CH || indentCh > MAX_INDENT_CH) {
+    return null;
+  }
+  return { indentCh, listPrefix };
+};
+
+const resolveDivider = (agent: SmartWrapAgent, text: string) => {
+  if (agent === "codex") {
+    return isCodexDivider(text);
+  }
+  if (agent === "claude") {
+    return isClaudeDivider(text);
+  }
+  return false;
+};
+
+export const classifySmartWrapLines = (
+  lineHtmlList: string[],
+  agent: SmartWrapAgent,
+): SmartWrapLineClassification[] => {
+  const textLines = lineHtmlList.map((lineHtml) => extractTextContentFromHtml(lineHtml));
+  const codexDiffBlockLineSet =
+    agent === "codex" ? detectCodexDiffBlockLineSet(textLines) : new Set<number>();
+  const claudeToolBlockLineSet =
+    agent === "claude"
+      ? detectBlockLineSet(
+          textLines,
+          (line) => CLAUDE_TOOL_START_PATTERN.test(line),
+          (line) => matchesAny(line, CLAUDE_TOOL_CONTINUATION_PATTERNS),
+        )
+      : new Set<number>();
+
+  return lineHtmlList.map((lineHtml, index) => {
+    const text = textLines[index] ?? "";
+    const isLastLine = index === lineHtmlList.length - 1;
+    if (isLastLine && (agent === "codex" || agent === "claude")) {
+      return {
+        rule: "statusline-preserve",
+        indentCh: null,
+        listPrefix: null,
+      };
+    }
+    if (claudeToolBlockLineSet.has(index)) {
+      return {
+        rule: "claude-tool-block",
+        indentCh: null,
+        listPrefix: null,
+      };
+    }
+    if (codexDiffBlockLineSet.has(index)) {
+      return {
+        rule: "codex-diff-block",
+        indentCh: null,
+        listPrefix: null,
+      };
+    }
+    if (isTableLine(lineHtml)) {
+      return {
+        rule: "table-preserve",
+        indentCh: null,
+        listPrefix: null,
+      };
+    }
+    if (resolveDivider(agent, text)) {
+      return {
+        rule: "divider-clip",
+        indentCh: null,
+        listPrefix: null,
+      };
+    }
+    const labelIndent =
+      agent === "codex"
+        ? resolveCodexLabelIndent(text)
+        : agent === "claude"
+          ? resolveClaudeLabelIndent(text)
+          : null;
+    if (labelIndent != null) {
+      return {
+        rule: "label-indent",
+        indentCh: labelIndent,
+        listPrefix: null,
+      };
+    }
+    const listLongWord = resolveListLongWord(agent, text);
+    if (listLongWord) {
+      return {
+        rule: "list-long-word",
+        indentCh: listLongWord.indentCh,
+        listPrefix: listLongWord.listPrefix,
+      };
+    }
+    const genericIndent = resolveGenericIndent(text);
+    if (genericIndent != null) {
+      return {
+        rule: "generic-indent",
+        indentCh: genericIndent,
+        listPrefix: null,
+      };
+    }
+    return {
+      rule: "default",
+      indentCh: null,
+      listPrefix: null,
+    };
+  });
+};
+
+export const __testables = {
+  extractTextContentFromHtml,
+};

--- a/apps/web/src/pages/SessionDetail/smart-wrap-decorator.test.ts
+++ b/apps/web/src/pages/SessionDetail/smart-wrap-decorator.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from "vitest";
+
+import { classifySmartWrapLines } from "./smart-wrap-classify";
+import { decorateSmartWrapLines } from "./smart-wrap-decorator";
+
+describe("decorateSmartWrapLines", () => {
+  it("keeps linkify element structure while applying text-node smart decoration", () => {
+    const line =
+      '- <span data-vde-file-ref="src/very/very/long/path/file.ts">src/very/very/long/path/file.ts</span>';
+    const statusLine = "43% left";
+    const classifications = classifySmartWrapLines([line, statusLine], "codex");
+    const [decorated] = decorateSmartWrapLines([line, statusLine], classifications);
+
+    const document = new DOMParser().parseFromString(
+      `<div>${decorated?.lineHtml}</div>`,
+      "text/html",
+    );
+    const fileRefElement = document.querySelector<HTMLElement>("[data-vde-file-ref]");
+    const hangElement = document.querySelector<HTMLElement>(".vde-smart-wrap-hang");
+
+    expect(fileRefElement?.dataset.vdeFileRef).toBe("src/very/very/long/path/file.ts");
+    expect(hangElement).not.toBeNull();
+  });
+});

--- a/apps/web/src/pages/SessionDetail/smart-wrap-decorator.ts
+++ b/apps/web/src/pages/SessionDetail/smart-wrap-decorator.ts
@@ -1,0 +1,16 @@
+import type { SmartWrapLineClassification } from "./smart-wrap-classify";
+import { decorateSmartWrapLine, type SmartWrapDecoratedLine } from "./smart-wrap-line";
+
+const defaultClassification: SmartWrapLineClassification = {
+  rule: "default",
+  indentCh: null,
+  listPrefix: null,
+};
+
+export const decorateSmartWrapLines = (
+  lineHtmlList: string[],
+  classifications: SmartWrapLineClassification[],
+): SmartWrapDecoratedLine[] =>
+  lineHtmlList.map((lineHtml, index) =>
+    decorateSmartWrapLine(lineHtml, classifications[index] ?? defaultClassification),
+  );

--- a/apps/web/src/pages/SessionDetail/smart-wrap-decorator.ts
+++ b/apps/web/src/pages/SessionDetail/smart-wrap-decorator.ts
@@ -1,5 +1,5 @@
-import type { SmartWrapLineClassification } from "./smart-wrap-classify";
 import { decorateSmartWrapLine, type SmartWrapDecoratedLine } from "./smart-wrap-line";
+import type { SmartWrapLineClassification } from "./smart-wrap-types";
 
 const defaultClassification: SmartWrapLineClassification = {
   rule: "default",

--- a/apps/web/src/pages/SessionDetail/smart-wrap-line.test.ts
+++ b/apps/web/src/pages/SessionDetail/smart-wrap-line.test.ts
@@ -1,0 +1,90 @@
+import { describe, expect, it } from "vitest";
+
+import { classifySmartWrapLines } from "./smart-wrap-classify";
+import { decorateSmartWrapLine } from "./smart-wrap-line";
+
+const parseLine = (lineHtml: string) =>
+  new DOMParser().parseFromString(`<div>${lineHtml}</div>`, "text/html").body.firstElementChild;
+
+describe("decorateSmartWrapLine", () => {
+  it("adds preserve-row class for table lines", () => {
+    const line = '<span class="vde-unicode-table-wrap">table</span>';
+    const classification = classifySmartWrapLines([line, "43% left"], "codex")[0]!;
+    const decorated = decorateSmartWrapLine(line, classification);
+    expect(decorated.className).toBe("vde-smart-wrap-preserve-row");
+  });
+
+  it("adds statusline class for codex/claude last line", () => {
+    const codexClass = classifySmartWrapLines(["line", "43% left"], "codex")[1]!;
+    const claudeClass = classifySmartWrapLines(["line", "❯ "], "claude")[1]!;
+    expect(decorateSmartWrapLine("43% left", codexClass).className).toBe(
+      "vde-smart-wrap-statusline",
+    );
+    expect(decorateSmartWrapLine("❯ ", claudeClass).className).toBe("vde-smart-wrap-statusline");
+  });
+
+  it("applies non-break gap for list line with long leading token", () => {
+    const line = "- supercalifragilisticexpialidocious token";
+    const classification = classifySmartWrapLines([line, "43% left"], "codex")[0]!;
+    const decorated = decorateSmartWrapLine(line, classification);
+    const node = parseLine(decorated.lineHtml);
+    expect(node?.textContent).toContain("-\u00A0supercalifragilisticexpialidocious");
+  });
+
+  it("applies non-break gap even when list prefix is split across html nodes", () => {
+    const line =
+      '<span class="token">-</span> <span class="token">apps/web/src/pages/SessionDetail/components/ScreenPanelViewport.tsx:19</span>';
+    const classification = classifySmartWrapLines([line, "43% left"], "codex")[0]!;
+    const decorated = decorateSmartWrapLine(line, classification);
+    const node = parseLine(decorated.lineHtml);
+    expect(classification.rule).toBe("list-long-word");
+    expect(node?.textContent).toContain(
+      "-\u00A0apps/web/src/pages/SessionDetail/components/ScreenPanelViewport.tsx:19",
+    );
+  });
+
+  it("adds divider class for codex divider candidate", () => {
+    const line = "----------";
+    const classification = classifySmartWrapLines([line, "43% left"], "codex")[0]!;
+    const decorated = decorateSmartWrapLine(line, classification);
+    expect(decorated.className).toBe("vde-smart-wrap-divider");
+  });
+
+  it("adds divider class for claude divider candidate", () => {
+    const line = "────────────────────────────────";
+    const classification = classifySmartWrapLines([line, "❯ "], "claude")[0]!;
+    const decorated = decorateSmartWrapLine(line, classification);
+    expect(decorated.className).toBe("vde-smart-wrap-divider");
+  });
+
+  it("uses label tail as hanging-indent anchor for codex search line", () => {
+    const line = "Search very-long-keyword-list";
+    const classification = classifySmartWrapLines([line, "43% left"], "codex")[0]!;
+    const decorated = decorateSmartWrapLine(line, classification);
+    const wrapper = parseLine(decorated.lineHtml)?.querySelector(".vde-smart-wrap-hang");
+    expect(wrapper?.getAttribute("style")).toContain("--vde-wrap-indent-ch: 7ch");
+  });
+
+  it("keeps claude bash line as no-wrap tool block", () => {
+    const line = "⏺ Bash(mkdir -p /tmp/example/path)";
+    const classification = classifySmartWrapLines([line, "❯ "], "claude")[0]!;
+    const decorated = decorateSmartWrapLine(line, classification);
+    const wrapper = parseLine(decorated.lineHtml)?.querySelector(".vde-smart-wrap-hang");
+    expect(wrapper).toBeNull();
+    expect(decorated.className).toBe("vde-smart-wrap-claude-block");
+  });
+
+  it("adds codex diff-block class", () => {
+    const lines = ["• Edited a.ts (+1 -1)", "  10  line"];
+    const classifications = classifySmartWrapLines(lines, "codex");
+    const decorated = decorateSmartWrapLine(lines[0]!, classifications[0]!);
+    expect(decorated.className).toBe("vde-smart-wrap-diff-block");
+  });
+
+  it("adds claude tool-block class", () => {
+    const line = "⏺ Read 1 file";
+    const classification = classifySmartWrapLines([line, "❯ "], "claude")[0]!;
+    const decorated = decorateSmartWrapLine(line, classification);
+    expect(decorated.className).toBe("vde-smart-wrap-claude-block");
+  });
+});

--- a/apps/web/src/pages/SessionDetail/smart-wrap-line.ts
+++ b/apps/web/src/pages/SessionDetail/smart-wrap-line.ts
@@ -1,0 +1,127 @@
+import type { SmartWrapLineClassification } from "./smart-wrap-classify";
+
+export type SmartWrapDecoratedLine = {
+  lineHtml: string;
+  className: string;
+};
+
+const sharedParser = typeof DOMParser === "undefined" ? null : new DOMParser();
+
+const HANGING_INDENT_RULES = new Set(["label-indent", "list-long-word", "generic-indent"]);
+
+const replaceTrailingPrefixSpaceWithNbsp = (value: string) => {
+  const match = value.match(/^(.*?)(\s+)$/);
+  if (!match) {
+    return value;
+  }
+  const prefixBody = match[1] ?? "";
+  const trailingSpaces = match[2] ?? "";
+  if (trailingSpaces.length === 0) {
+    return value;
+  }
+  return `${prefixBody}\u00A0${trailingSpaces.slice(1)}`;
+};
+
+const applyListLongWordNonBreakGap = (container: Element, listPrefix: string) => {
+  const textContent = container.textContent ?? "";
+  if (!textContent.startsWith(listPrefix)) {
+    return;
+  }
+  const gapOffset = listPrefix.lastIndexOf(" ");
+  if (gapOffset < 0) {
+    return;
+  }
+  const walker = container.ownerDocument.createTreeWalker(container, NodeFilter.SHOW_TEXT);
+  let textOffset = 0;
+  let currentNode = walker.nextNode();
+  while (currentNode) {
+    const textNode = currentNode as Text;
+    const value = textNode.nodeValue ?? "";
+    const nextTextOffset = textOffset + value.length;
+    if (gapOffset < nextTextOffset) {
+      const gapOffsetInNode = gapOffset - textOffset;
+      if (value[gapOffsetInNode] === " ") {
+        textNode.nodeValue =
+          `${value.slice(0, gapOffsetInNode)}\u00A0` + value.slice(gapOffsetInNode + 1);
+      }
+      return;
+    }
+    textOffset = nextTextOffset;
+    currentNode = walker.nextNode();
+  }
+};
+
+const applyHangingIndentWrapper = (container: Element, indentCh: number) => {
+  const wrapper = container.ownerDocument.createElement("span");
+  wrapper.className = "vde-smart-wrap-hang";
+  wrapper.style.setProperty("--vde-wrap-indent-ch", `${indentCh}ch`);
+  while (container.firstChild) {
+    wrapper.append(container.firstChild);
+  }
+  container.append(wrapper);
+};
+
+const resolveClassName = (classification: SmartWrapLineClassification): string => {
+  if (classification.rule === "statusline-preserve") {
+    return "vde-smart-wrap-statusline";
+  }
+  if (classification.rule === "table-preserve") {
+    return "vde-smart-wrap-preserve-row";
+  }
+  if (classification.rule === "divider-clip") {
+    return "vde-smart-wrap-divider";
+  }
+  if (classification.rule === "codex-diff-block") {
+    return "vde-smart-wrap-diff-block";
+  }
+  if (classification.rule === "claude-tool-block") {
+    return "vde-smart-wrap-claude-block";
+  }
+  return "";
+};
+
+const applyFallbackListLongWord = (lineHtml: string, listPrefix: string) => {
+  if (!lineHtml.startsWith(listPrefix)) {
+    return lineHtml;
+  }
+  const replacementPrefix = replaceTrailingPrefixSpaceWithNbsp(listPrefix);
+  return `${replacementPrefix}${lineHtml.slice(listPrefix.length)}`;
+};
+
+export const decorateSmartWrapLine = (
+  lineHtml: string,
+  classification: SmartWrapLineClassification,
+): SmartWrapDecoratedLine => {
+  if (!sharedParser) {
+    const normalized =
+      classification.rule === "list-long-word" && classification.listPrefix
+        ? applyFallbackListLongWord(lineHtml, classification.listPrefix)
+        : lineHtml;
+    return {
+      lineHtml: normalized,
+      className: resolveClassName(classification),
+    };
+  }
+
+  const document = sharedParser.parseFromString(`<div>${lineHtml}</div>`, "text/html");
+  const container = document.body.firstElementChild;
+  if (!container) {
+    return {
+      lineHtml,
+      className: resolveClassName(classification),
+    };
+  }
+
+  if (classification.rule === "list-long-word" && classification.listPrefix) {
+    applyListLongWordNonBreakGap(container, classification.listPrefix);
+  }
+
+  if (HANGING_INDENT_RULES.has(classification.rule) && classification.indentCh != null) {
+    applyHangingIndentWrapper(container, classification.indentCh);
+  }
+
+  return {
+    lineHtml: container.innerHTML,
+    className: resolveClassName(classification),
+  };
+};

--- a/apps/web/src/pages/SessionDetail/smart-wrap-line.ts
+++ b/apps/web/src/pages/SessionDetail/smart-wrap-line.ts
@@ -1,4 +1,4 @@
-import type { SmartWrapLineClassification } from "./smart-wrap-classify";
+import type { SmartWrapLineClassification } from "./smart-wrap-types";
 
 export type SmartWrapDecoratedLine = {
   lineHtml: string;

--- a/apps/web/src/pages/SessionDetail/smart-wrap-rules.ts
+++ b/apps/web/src/pages/SessionDetail/smart-wrap-rules.ts
@@ -88,14 +88,13 @@ const resolveClaudeLabelIndent = (text: string): number | null => {
   if (!match) {
     return null;
   }
-  let anchor = match[0].length;
-  const nextChar = text[anchor];
-  if (nextChar === "(") {
-    anchor += 1;
-  } else if (nextChar === " ") {
+  const codePoints = [...text];
+  let anchor = countCh(match[0]);
+  const nextChar = codePoints[anchor];
+  if (nextChar === "(" || nextChar === " ") {
     anchor += 1;
   }
-  return countCh(text.slice(0, anchor));
+  return anchor;
 };
 
 export const isTableLine = (lineHtml: string) =>

--- a/apps/web/src/pages/SessionDetail/smart-wrap-rules.ts
+++ b/apps/web/src/pages/SessionDetail/smart-wrap-rules.ts
@@ -1,0 +1,230 @@
+import { countCh, isBlankLikeLine, matchesAny } from "./smart-wrap-text";
+import type { SmartWrapAgent } from "./smart-wrap-types";
+
+const LIST_LONG_WORD_THRESHOLD_CH = 12;
+const MIN_INDENT_CH = 2;
+const MAX_INDENT_CH = 24;
+const CODEX_DIFF_START_PATTERNS = [
+  /^\s*•\s+(Edited|Added|Deleted|Renamed)\s+.+\(\+\d+\s+-\d+\)\s*$/,
+  /^\s*•\s+(Edited|Added|Deleted|Renamed)\s+.+\(\+\d+\)\s*$/,
+  /^\s*•\s+(Edited|Added|Deleted|Renamed)\s+\S*(?:\/|\\|\.)\S*(?:\s+\(\+\d+(?:\s+-\d+)?\))?\s*$/,
+];
+const CODEX_DIFF_CONTINUATION_PATTERNS = [
+  /^\s*\d+\s{2,}.*$/,
+  /^\s*\d+\s+[+-]\s?.*$/,
+  /^\s+[+-]\s.*$/,
+  /^\s+(?:⋮|:)\s*$/,
+];
+const CODEX_LABELED_DIVIDER_PATTERN = /^\s*[─━-]\s+Worked for\b.+[─━-]{8,}\s*$/;
+const MAX_CODEX_WRAPPED_FRAGMENT_LINES = 3;
+const CLAUDE_TOOL_START_PATTERN = /^\s*⏺\s+(Read|Bash|Write|Update|Edit|MultiEdit)\b.*$/;
+const CLAUDE_TOOL_CONTINUATION_PATTERNS = [/^\s{2,}⎿\s+.*$/, /^\s{6,}\d+\s+.*$/, /^\s{6,}$/];
+const CODEX_LABEL_PATTERN = /^\s*(?:[│└├]\s*)?(Search|Read)\s+/;
+const CLAUDE_LABEL_PATTERN = /^\s*⏺\s+(Read|Bash|Write|Update|Edit|MultiEdit)\b/;
+const LIST_LONG_WORD_PATTERN = /^(\s*(?:[-*+]\s+|\d+[.)]\s+))(\S+)/;
+const GENERIC_INDENT_PATTERNS = [
+  /^\s*(?:[-*+•]\s+|\d+[.)]\s+|[A-Za-z]\)\s+)/,
+  /^\s*>\s+/,
+  /^\s*(?:\[\d{1,2}:\d{2}:\d{2}\]\s+)?(?:TRACE|DEBUG|INFO|WARN|ERROR|FATAL)\s+/,
+];
+
+const detectBlockLineSet = (
+  textLines: string[],
+  isStart: (line: string) => boolean,
+  isContinuation: (line: string) => boolean,
+) => {
+  const result = new Set<number>();
+  let index = 0;
+  while (index < textLines.length) {
+    const current = textLines[index] ?? "";
+    if (!isStart(current)) {
+      index += 1;
+      continue;
+    }
+    result.add(index);
+    let nextIndex = index + 1;
+    while (nextIndex < textLines.length) {
+      const next = textLines[nextIndex] ?? "";
+      if (!isContinuation(next)) {
+        break;
+      }
+      result.add(nextIndex);
+      nextIndex += 1;
+    }
+    index = nextIndex;
+  }
+  return result;
+};
+
+const isCodexDivider = (text: string) => {
+  const trimmed = text.trim();
+  if (trimmed.length < 6) {
+    return false;
+  }
+  if (CODEX_LABELED_DIVIDER_PATTERN.test(trimmed)) {
+    return true;
+  }
+  if (/[A-Za-z0-9]/.test(trimmed)) {
+    return false;
+  }
+  return /^[-=_*─━]+$/.test(trimmed);
+};
+
+const isClaudeDivider = (text: string) => {
+  const trimmed = text.trim();
+  return /^─{20,}$/.test(trimmed) || /^[╭╰]─{10,}[╮╯]$/.test(trimmed);
+};
+
+const resolveCodexLabelIndent = (text: string): number | null => {
+  const match = text.match(CODEX_LABEL_PATTERN);
+  if (!match) {
+    return null;
+  }
+  return countCh(match[0]);
+};
+
+const resolveClaudeLabelIndent = (text: string): number | null => {
+  const match = text.match(CLAUDE_LABEL_PATTERN);
+  if (!match) {
+    return null;
+  }
+  let anchor = match[0].length;
+  const nextChar = text[anchor];
+  if (nextChar === "(") {
+    anchor += 1;
+  } else if (nextChar === " ") {
+    anchor += 1;
+  }
+  return countCh(text.slice(0, anchor));
+};
+
+export const isTableLine = (lineHtml: string) =>
+  lineHtml.includes("vde-unicode-table-wrap") || lineHtml.includes("vde-markdown-pipe-table-wrap");
+
+export const detectCodexDiffBlockLineSet = (textLines: string[]) => {
+  const result = new Set<number>();
+  let index = 0;
+  while (index < textLines.length) {
+    const current = textLines[index] ?? "";
+    if (!matchesAny(current, CODEX_DIFF_START_PATTERNS)) {
+      index += 1;
+      continue;
+    }
+    result.add(index);
+    let nextIndex = index + 1;
+    while (nextIndex < textLines.length) {
+      const next = textLines[nextIndex] ?? "";
+      if (matchesAny(next, CODEX_DIFF_CONTINUATION_PATTERNS)) {
+        result.add(nextIndex);
+        nextIndex += 1;
+        continue;
+      }
+
+      const wrappedStart = nextIndex;
+      const wrappedMaxExclusive = Math.min(
+        textLines.length,
+        wrappedStart + MAX_CODEX_WRAPPED_FRAGMENT_LINES,
+      );
+      while (nextIndex < textLines.length) {
+        const candidate = textLines[nextIndex] ?? "";
+        if (isBlankLikeLine(candidate)) {
+          break;
+        }
+        if (isCodexDivider(candidate)) {
+          break;
+        }
+        if (matchesAny(candidate, CODEX_DIFF_START_PATTERNS)) {
+          break;
+        }
+        if (matchesAny(candidate, CODEX_DIFF_CONTINUATION_PATTERNS)) {
+          break;
+        }
+        nextIndex += 1;
+        if (nextIndex >= wrappedMaxExclusive) {
+          break;
+        }
+      }
+
+      if (
+        nextIndex > wrappedStart &&
+        nextIndex < textLines.length &&
+        matchesAny(textLines[nextIndex] ?? "", CODEX_DIFF_CONTINUATION_PATTERNS)
+      ) {
+        for (let cursor = wrappedStart; cursor < nextIndex; cursor += 1) {
+          result.add(cursor);
+        }
+        continue;
+      }
+
+      nextIndex = wrappedStart;
+      break;
+    }
+    index = nextIndex;
+  }
+  return result;
+};
+
+export const detectClaudeToolBlockLineSet = (textLines: string[]) =>
+  detectBlockLineSet(
+    textLines,
+    (line) => CLAUDE_TOOL_START_PATTERN.test(line),
+    (line) => matchesAny(line, CLAUDE_TOOL_CONTINUATION_PATTERNS),
+  );
+
+export const resolveDivider = (agent: SmartWrapAgent, text: string) => {
+  if (agent === "codex") {
+    return isCodexDivider(text);
+  }
+  if (agent === "claude") {
+    return isClaudeDivider(text);
+  }
+  return false;
+};
+
+export const resolveLabelIndent = (agent: SmartWrapAgent, text: string): number | null => {
+  if (agent === "codex") {
+    return resolveCodexLabelIndent(text);
+  }
+  if (agent === "claude") {
+    return resolveClaudeLabelIndent(text);
+  }
+  return null;
+};
+
+export const resolveListLongWord = (
+  agent: SmartWrapAgent,
+  text: string,
+): { indentCh: number; listPrefix: string } | null => {
+  if (agent !== "codex") {
+    return null;
+  }
+  const match = text.match(LIST_LONG_WORD_PATTERN);
+  if (!match) {
+    return null;
+  }
+  const listPrefix = match[1] ?? "";
+  const firstToken = match[2] ?? "";
+  if (countCh(firstToken) < LIST_LONG_WORD_THRESHOLD_CH) {
+    return null;
+  }
+  const indentCh = countCh(listPrefix);
+  if (indentCh < MIN_INDENT_CH || indentCh > MAX_INDENT_CH) {
+    return null;
+  }
+  return { indentCh, listPrefix };
+};
+
+export const resolveGenericIndent = (text: string): number | null => {
+  for (const pattern of GENERIC_INDENT_PATTERNS) {
+    const match = text.match(pattern);
+    if (!match) {
+      continue;
+    }
+    const indentCh = countCh(match[0]);
+    if (indentCh < MIN_INDENT_CH || indentCh > MAX_INDENT_CH) {
+      return null;
+    }
+    return indentCh;
+  }
+  return null;
+};

--- a/apps/web/src/pages/SessionDetail/smart-wrap-rules.ts
+++ b/apps/web/src/pages/SessionDetail/smart-wrap-rules.ts
@@ -119,6 +119,12 @@ export const detectCodexDiffBlockLineSet = (textLines: string[]) => {
         continue;
       }
 
+      // Two-phase recovery for wrapped Codex diff fragments:
+      // 1) after explicit continuation lines end, perform bounded lookahead
+      //    (up to wrappedMaxExclusive) to consume only plain wrapped text.
+      // 2) absorb that fragment only when a continuation line follows.
+      // This loop always makes progress: lookahead is bounded, absorption
+      // requires at least one consumed line, and fallback resets to wrappedStart.
       const wrappedStart = nextIndex;
       const wrappedMaxExclusive = Math.min(
         textLines.length,
@@ -221,7 +227,7 @@ export const resolveGenericIndent = (text: string): number | null => {
     }
     const indentCh = countCh(match[0]);
     if (indentCh < MIN_INDENT_CH || indentCh > MAX_INDENT_CH) {
-      return null;
+      continue;
     }
     return indentCh;
   }

--- a/apps/web/src/pages/SessionDetail/smart-wrap-text.ts
+++ b/apps/web/src/pages/SessionDetail/smart-wrap-text.ts
@@ -1,0 +1,21 @@
+const sharedParser = typeof DOMParser === "undefined" ? null : new DOMParser();
+
+export const stripInvisibleChars = (value: string) => value.replace(/[\u200B\uFEFF]/g, "");
+
+export const extractTextContentFromHtml = (lineHtml: string) => {
+  if (!lineHtml) {
+    return "";
+  }
+  if (!sharedParser) {
+    return stripInvisibleChars(lineHtml.replace(/<[^>]*>/g, ""));
+  }
+  const document = sharedParser.parseFromString(`<div>${lineHtml}</div>`, "text/html");
+  return stripInvisibleChars(document.body.firstElementChild?.textContent ?? "");
+};
+
+export const countCh = (value: string) => [...value].length;
+
+export const matchesAny = (value: string, patterns: RegExp[]) =>
+  patterns.some((pattern) => pattern.test(value));
+
+export const isBlankLikeLine = (value: string) => stripInvisibleChars(value).trim().length === 0;

--- a/apps/web/src/pages/SessionDetail/smart-wrap-text.ts
+++ b/apps/web/src/pages/SessionDetail/smart-wrap-text.ts
@@ -9,8 +9,8 @@ export const extractTextContentFromHtml = (lineHtml: string) => {
   if (!sharedParser) {
     return stripInvisibleChars(lineHtml.replace(/<[^>]*>/g, ""));
   }
-  const document = sharedParser.parseFromString(`<div>${lineHtml}</div>`, "text/html");
-  return stripInvisibleChars(document.body.firstElementChild?.textContent ?? "");
+  const parsedDocument = sharedParser.parseFromString(`<div>${lineHtml}</div>`, "text/html");
+  return stripInvisibleChars(parsedDocument.body.firstElementChild?.textContent ?? "");
 };
 
 export const countCh = (value: string) => [...value].length;

--- a/apps/web/src/pages/SessionDetail/smart-wrap-types.ts
+++ b/apps/web/src/pages/SessionDetail/smart-wrap-types.ts
@@ -1,0 +1,18 @@
+export type SmartWrapAgent = "codex" | "claude" | "unknown";
+
+export type SmartWrapLineRule =
+  | "default"
+  | "statusline-preserve"
+  | "claude-tool-block"
+  | "codex-diff-block"
+  | "table-preserve"
+  | "divider-clip"
+  | "label-indent"
+  | "list-long-word"
+  | "generic-indent";
+
+export type SmartWrapLineClassification = {
+  rule: SmartWrapLineRule;
+  indentCh: number | null;
+  listPrefix: string | null;
+};

--- a/apps/web/src/pages/SessionDetail/useSessionDetailVM.test.tsx
+++ b/apps/web/src/pages/SessionDetail/useSessionDetailVM.test.tsx
@@ -51,6 +51,7 @@ vi.mock("@/lib/use-split-ratio", () => ({
 vi.mock("./hooks/useSessionScreen", () => ({
   useSessionScreen: () => ({
     mode: "text",
+    wrapMode: "off",
     screenLines: ["line"],
     imageBase64: null,
     fallbackReason: null,
@@ -65,6 +66,7 @@ vi.mock("./hooks/useSessionScreen", () => ({
     refreshScreen: vi.fn(),
     scrollToBottom: vi.fn(),
     handleModeChange: vi.fn(),
+    toggleWrapMode: vi.fn(),
     virtuosoRef: { current: null },
     scrollerRef: { current: null },
   }),

--- a/apps/web/src/pages/SessionDetail/useSessionDetailVM.ts
+++ b/apps/web/src/pages/SessionDetail/useSessionDetailVM.ts
@@ -62,6 +62,7 @@ export const useSessionDetailVM = (paneId: string) => {
   const {
     screen: {
       mode,
+      wrapMode,
       screenLines,
       imageBase64,
       fallbackReason,
@@ -75,6 +76,7 @@ export const useSessionDetailVM = (paneId: string) => {
       forceFollow,
       scrollToBottom,
       handleModeChange,
+      toggleWrapMode,
       virtuosoRef,
       scrollerRef,
     },
@@ -301,6 +303,7 @@ export const useSessionDetailVM = (paneId: string) => {
     },
     screen: {
       mode,
+      wrapMode,
       screenLines,
       imageBase64,
       fallbackReason,
@@ -314,6 +317,7 @@ export const useSessionDetailVM = (paneId: string) => {
       forceFollow,
       scrollToBottom,
       handleModeChange,
+      toggleWrapMode,
       virtuosoRef,
       scrollerRef,
       handleRefreshScreen,

--- a/packages/shared/src/constants.ts
+++ b/packages/shared/src/constants.ts
@@ -104,7 +104,7 @@ export const defaultConfig: AgentMonitorConfigFile = {
     defaultLines: 2000,
     maxLines: 2000,
     includeTruncated: false,
-    joinLines: true,
+    joinLines: false,
     ansi: true,
     altScreen: "auto",
     highlightCorrection: {

--- a/packages/shared/src/constants.ts
+++ b/packages/shared/src/constants.ts
@@ -104,7 +104,7 @@ export const defaultConfig: AgentMonitorConfigFile = {
     defaultLines: 2000,
     maxLines: 2000,
     includeTruncated: false,
-    joinLines: false,
+    joinLines: true,
     ansi: true,
     altScreen: "auto",
     highlightCorrection: {

--- a/packages/shared/src/schemas.ts
+++ b/packages/shared/src/schemas.ts
@@ -37,11 +37,14 @@ const screenDeltaSchema = z.object({
 
 const screenCaptureMetaSchema = z.object({
   backend: z.enum(["tmux", "wezterm", "unknown"]),
+  // "logical" is reserved for future backends/modes that can return logical lines.
   lineModel: z.enum(["joined-physical", "physical", "logical", "none"]),
   joinLinesApplied: z.boolean().nullable(),
+  // Geometry fields stay nullable until all capture backends expose these metrics.
   paneCols: z.number().nullable(),
   paneRows: z.number().nullable(),
   scrollbackRows: z.number().nullable(),
+  // "wezterm-logical-lines" is reserved for future wezterm logical-line capture support.
   captureMethod: z.enum([
     "tmux-capture-pane",
     "wezterm-get-text",

--- a/packages/shared/src/schemas.ts
+++ b/packages/shared/src/schemas.ts
@@ -40,10 +40,6 @@ const screenCaptureMetaSchema = z.object({
   // "logical" is reserved for future backends/modes that can return logical lines.
   lineModel: z.enum(["joined-physical", "physical", "logical", "none"]),
   joinLinesApplied: z.boolean().nullable(),
-  // Geometry fields stay nullable until all capture backends expose these metrics.
-  paneCols: z.number().nullable(),
-  paneRows: z.number().nullable(),
-  scrollbackRows: z.number().nullable(),
   // "wezterm-logical-lines" is reserved for future wezterm logical-line capture support.
   captureMethod: z.enum([
     "tmux-capture-pane",

--- a/packages/shared/src/schemas.ts
+++ b/packages/shared/src/schemas.ts
@@ -35,11 +35,28 @@ const screenDeltaSchema = z.object({
   insertLines: z.array(z.string()),
 });
 
+const screenCaptureMetaSchema = z.object({
+  backend: z.enum(["tmux", "wezterm", "unknown"]),
+  lineModel: z.enum(["joined-physical", "physical", "logical", "none"]),
+  joinLinesApplied: z.boolean().nullable(),
+  paneCols: z.number().nullable(),
+  paneRows: z.number().nullable(),
+  scrollbackRows: z.number().nullable(),
+  captureMethod: z.enum([
+    "tmux-capture-pane",
+    "wezterm-get-text",
+    "wezterm-logical-lines",
+    "terminal-image",
+    "none",
+  ]),
+});
+
 export const screenResponseSchema = z.object({
   ok: z.boolean(),
   paneId: z.string(),
   mode: z.enum(["text", "image"]),
   capturedAt: z.string(),
+  captureMeta: screenCaptureMetaSchema.optional(),
   cursor: z.string().optional(),
   lines: z.number().optional(),
   truncated: z.boolean().nullable().optional(),

--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -303,11 +303,27 @@ export type ApiEnvelope<T> = T & {
   error?: ApiError;
 };
 
+export type ScreenCaptureMeta = {
+  backend: "tmux" | "wezterm" | "unknown";
+  lineModel: "joined-physical" | "physical" | "logical" | "none";
+  joinLinesApplied: boolean | null;
+  paneCols: number | null;
+  paneRows: number | null;
+  scrollbackRows: number | null;
+  captureMethod:
+    | "tmux-capture-pane"
+    | "wezterm-get-text"
+    | "wezterm-logical-lines"
+    | "terminal-image"
+    | "none";
+};
+
 export type ScreenResponse = {
   ok: boolean;
   paneId: string;
   mode: "text" | "image";
   capturedAt: string;
+  captureMeta?: ScreenCaptureMeta;
   cursor?: string;
   lines?: number;
   truncated?: boolean | null;

--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -308,10 +308,6 @@ export type ScreenCaptureMeta = {
   // "logical" is reserved for future backends/modes that can return logical lines.
   lineModel: "joined-physical" | "physical" | "logical" | "none";
   joinLinesApplied: boolean | null;
-  // Geometry fields remain nullable until all capture backends expose these metrics.
-  paneCols: number | null;
-  paneRows: number | null;
-  scrollbackRows: number | null;
   // "wezterm-logical-lines" is reserved for future wezterm logical-line capture support.
   captureMethod:
     | "tmux-capture-pane"

--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -305,11 +305,14 @@ export type ApiEnvelope<T> = T & {
 
 export type ScreenCaptureMeta = {
   backend: "tmux" | "wezterm" | "unknown";
+  // "logical" is reserved for future backends/modes that can return logical lines.
   lineModel: "joined-physical" | "physical" | "logical" | "none";
   joinLinesApplied: boolean | null;
+  // Geometry fields remain nullable until all capture backends expose these metrics.
   paneCols: number | null;
   paneRows: number | null;
   scrollbackRows: number | null;
+  // "wezterm-logical-lines" is reserved for future wezterm logical-line capture support.
   captureMethod:
     | "tmux-capture-pane"
     | "wezterm-get-text"


### PR DESCRIPTION
## Summary
- add SessionDetail screen wrap mode (`off` / `smart`) with localStorage persistence and Smart toggle wiring
- implement smart rendering path with line decoration/classification for codex/claude logs
- classify and preserve special rows (diff/tool/status/divider) and clip separator rows by viewport width
- update server screen response metadata/schema/types and expand tests around wrap, linkify range, and copy sanitization

## Validation
- `pnpm run ci`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Smart wrap mode for screen rendering with a Smart viewport, toggle control, and smart-wrap classification/decoration to improve readability.
  * Screen capture metadata now included in screen responses (captureMeta) for richer capture details.

* **Bug Fixes**
  * Clipboard copy now normalizes non‑breaking spaces to regular spaces.

* **Improvements**
  * Enhanced ANSI/Claude diff parsing and new CSS utilities for smarter line wrapping and whitespace handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->